### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web app
+        env:
+          EXPO_NO_TELEMETRY: 1
+        run: npx expo export -p web
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          commit_message: Deploy website


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Expo web bundle when changes land on main
- publish the generated `dist` directory to the `gh-pages` branch using the built-in token

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1e9c8b80c8323aa97f0fb8f9b1b90