### PR TITLE
chore: update node 22 support

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "@babel/core": "^7.28.4",
     "gh-pages": "^6.3.0"
   },
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "private": true
 }


### PR DESCRIPTION
## Summary
- update the GitHub Pages deployment workflow to use Node.js 22
- declare Node.js 22 as the required runtime via the package.json engines field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1fb9ca83c8323bd369ae3a4c38619