### PR TITLE
Refactor GitHub auth flow with token refresh and user state

### DIFF
--- a/components/apis/GitHubAPI.js
+++ b/components/apis/GitHubAPI.js
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import { storeData, deleteData } from "./StorageAPI";
+import { storeData, deleteData, readData } from "./StorageAPI";
 
 function parseAttachFile(text) {
   const pattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/;
@@ -23,7 +23,16 @@ const parseYaml = (yamlString) => {
   }
 };
 
+const GITHUB_CLIENT_ID = 'cd019fec05aa5b74ad81';
+const GITHUB_CLIENT_SECRET = '51d66fda4e5184bcc7a4ceaf99f78a8cf3acb028';
+const GITHUB_REDIRECT_URI = 'https://yougikou.github.io/openroutes/githubauth';
+const GITHUB_TOKEN_ENDPOINT = 'https://github.com/login/oauth/access_token';
+const GITHUB_PROXY_URL = 'https://cors-anywhere.azm.workers.dev/';
+const GITHUB_AUTH_STORAGE_KEY = 'github_auth';
+const TOKEN_REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+
 const fetchIssues = async (page = 1, perPage = 10, filters = {}, token) => {
+  const accessToken = typeof token === 'string' ? token : token?.accessToken;
   let url = `https://api.github.com/repos/${process.env.EXPO_PUBLIC_GITHUB_OWNER}/${process.env.EXPO_PUBLIC_GITHUB_REPO}/issues?page=${page}&per_page=${perPage}&labels=route`;
   Object.keys(filters).forEach(key => {
     url += `&${key}=${filters[key]}`;
@@ -31,11 +40,12 @@ const fetchIssues = async (page = 1, perPage = 10, filters = {}, token) => {
 
   try {
     var response = null;
-    if(token != null && token.length > 0) {
+    if(accessToken != null && accessToken.length > 0) {
       response = await fetch(url, {
         headers: {
-          'Authorization': `token ${token}`,
-          'Accept': 'application/vnd.github.v3+json'
+          'Authorization': `Bearer ${accessToken}`,
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28'
         }
       });
     } else {
@@ -99,6 +109,12 @@ const fetchIssues = async (page = 1, perPage = 10, filters = {}, token) => {
 };
 
 const createIssue = async (routeData, token) => {
+  const accessToken = typeof token === 'string' ? token : token?.accessToken;
+
+  if (!accessToken) {
+    throw new Error('GitHub access token is required to create an issue');
+  }
+
   routeData.coverimg = routeData.coverimg?`![img](${routeData.coverimg})`:'';
   routeData.geojson = `[file](${routeData.geojson})`;
 
@@ -125,8 +141,9 @@ const createIssue = async (routeData, token) => {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `token ${token}`,
-      'Accept': 'application/vnd.github.v3+json',
+      'Authorization': `Bearer ${accessToken}`,
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
     },
     body: JSON.stringify(issueData)
   });
@@ -139,33 +156,171 @@ const createIssue = async (routeData, token) => {
   return resJson;
 }
 
-const exchangeToken = async (cd) => {
-  const ci = 'cd019fec05aa5b74ad81';
-  const sc = '51d66fda4e5184bcc7a4ceaf99f78a8cf3acb028';
-  const ru = 'https://yougikou.github.io/openroutes/githubauth';
-  const proxyUrl = 'https://cors-anywhere.azm.workers.dev/';
-
+const persistGithubAuth = async (authPayload) => {
   try {
-    await deleteData("github_access_token");
-    const response = await fetch(proxyUrl + 'https://github.com/login/oauth/access_token', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': 'application/json'
-      },
-      body: `client_id=${ci}&client_secret=${sc}&code=${cd}&redirect_uri=${ru}`,
+    await storeData(GITHUB_AUTH_STORAGE_KEY, JSON.stringify(authPayload));
+  } catch (error) {
+    console.error('Failed to persist GitHub auth payload:', error);
+    throw error;
+  }
+  return authPayload;
+};
+
+const getStoredGithubAuth = async () => {
+  try {
+    const raw = await readData(GITHUB_AUTH_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch (error) {
+    console.error('Failed to read GitHub auth payload:', error);
+    return null;
+  }
+};
+
+const clearGithubAuth = async () => {
+  try {
+    await deleteData(GITHUB_AUTH_STORAGE_KEY);
+  } catch (error) {
+    console.error('Failed to clear GitHub auth payload:', error);
+  }
+};
+
+const tokenRequest = async (params) => {
+  const body = new URLSearchParams({
+    client_id: GITHUB_CLIENT_ID,
+    client_secret: GITHUB_CLIENT_SECRET,
+    ...params,
+  });
+
+  if (params.grant_type !== 'refresh_token') {
+    body.append('redirect_uri', GITHUB_REDIRECT_URI);
+  }
+
+  const response = await fetch(`${GITHUB_PROXY_URL}${GITHUB_TOKEN_ENDPOINT}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/json',
+    },
+    body: body.toString(),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(`GitHub token request failed with status ${response.status}`);
+  }
+
+  if (data.error) {
+    throw new Error(data.error_description || data.error);
+  }
+
+  const now = Date.now();
+  const expiresIn = data.expires_in ? Number(data.expires_in) : null;
+  const refreshTokenExpiresIn = data.refresh_token_expires_in ? Number(data.refresh_token_expires_in) : null;
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    tokenType: data.token_type,
+    scope: data.scope,
+    expiresAt: expiresIn ? now + expiresIn * 1000 : null,
+    refreshTokenExpiresAt: refreshTokenExpiresIn ? now + refreshTokenExpiresIn * 1000 : null,
+  };
+};
+
+const fetchGithubUser = async (accessToken) => {
+  const response = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load GitHub user: ${response.status}`);
+  }
+
+  const data = await response.json();
+  return {
+    id: data.id,
+    login: data.login,
+    avatarUrl: data.avatar_url,
+    name: data.name,
+  };
+};
+
+const exchangeToken = async (code) => {
+  try {
+    const tokenData = await tokenRequest({
+      code,
+      grant_type: 'authorization_code',
     });
 
-    const data = await response.json();
-    if (data.access_token) {
-      await storeData("github_access_token", data.access_token);
-    } else {
-      console.error('No access token found in response:', data);
-    }
+    const user = await fetchGithubUser(tokenData.accessToken);
+
+    return await persistGithubAuth({
+      ...tokenData,
+      user,
+      updatedAt: Date.now(),
+    });
   } catch (error) {
     console.error('Token exchange error:', error);
+    throw error;
   }
-}
+};
+
+const refreshGithubToken = async (currentAuth) => {
+  if (!currentAuth?.refreshToken) {
+    throw new Error('No refresh token available');
+  }
+
+  const tokenData = await tokenRequest({
+    grant_type: 'refresh_token',
+    refresh_token: currentAuth.refreshToken,
+  });
+
+  const user = await fetchGithubUser(tokenData.accessToken);
+
+  return await persistGithubAuth({
+    ...tokenData,
+    user,
+    updatedAt: Date.now(),
+  });
+};
+
+const hasValidGithubCredentials = (auth) => {
+  return Boolean(auth?.accessToken && auth?.user?.id);
+};
+
+const shouldRefreshGithubToken = (auth, thresholdMs = TOKEN_REFRESH_THRESHOLD_MS) => {
+  if (!auth?.expiresAt) {
+    return false;
+  }
+
+  return auth.expiresAt - Date.now() <= thresholdMs;
+};
+
+const ensureFreshGithubAuth = async () => {
+  let auth = await getStoredGithubAuth();
+  if (!auth) {
+    return null;
+  }
+
+  if (shouldRefreshGithubToken(auth) && auth.refreshToken) {
+    try {
+      auth = await refreshGithubToken(auth);
+    } catch (error) {
+      console.error('Failed to refresh GitHub token:', error);
+    }
+  }
+
+  return auth;
+};
 
 
 const uploadGeoJsonFile = async (geoJsonData) => {
@@ -216,4 +371,16 @@ async function uploadImgToImgur(base64Data) {
   }
 }
 
-export { fetchIssues, createIssue, exchangeToken, uploadGeoJsonFile, uploadImgFile };
+export {
+  fetchIssues,
+  createIssue,
+  exchangeToken,
+  refreshGithubToken,
+  getStoredGithubAuth,
+  clearGithubAuth,
+  hasValidGithubCredentials,
+  shouldRefreshGithubToken,
+  ensureFreshGithubAuth,
+  uploadGeoJsonFile,
+  uploadImgFile,
+};

--- a/components/screens/GithubAuthScreen.js
+++ b/components/screens/GithubAuthScreen.js
@@ -1,47 +1,53 @@
 import React, { useEffect, useState } from 'react';
-import { View } from 'react-native';
-import { useRoute } from '@react-navigation/native';
+import { Platform, View } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
 import { Text, Button } from 'react-native-paper';
 import i18n from '../i18n/i18n';
-import { exchangeToken } from "../apis/GitHubAPI";
-import { readData } from "../apis/StorageAPI";
+import { exchangeToken, getStoredGithubAuth, hasValidGithubCredentials } from "../apis/GitHubAPI";
 
 export default function GithubAuthScreen() {
-  const route = useRoute();
+  const { code: rawCode } = useLocalSearchParams();
   const [tokenStatus, setTokenStatus] = useState('checking');
 
   useEffect(() => {
     const retrieveToken = async () => {
       try {
-        const code = route.params?.code ?? null;
+        const codeParam = Array.isArray(rawCode) ? rawCode[0] : rawCode;
+        const code = codeParam ?? null;
         if (code) {
-          await exchangeToken(code);
-          window.location.replace(window.location.origin + window.location.pathname);
-        } else {
-          const token = await readData('github_access_token');
-          if (token) {
-            setTokenStatus('success');
-          } else {
-            setTokenStatus('failed');
+          const auth = await exchangeToken(code);
+          setTokenStatus(hasValidGithubCredentials(auth) ? 'success' : 'failed');
+          if (Platform.OS === 'web' && typeof window !== 'undefined') {
+            window.location.replace(window.location.origin + window.location.pathname);
           }
+        } else {
+          const auth = await getStoredGithubAuth();
+          setTokenStatus(hasValidGithubCredentials(auth) ? 'success' : 'failed');
         }
       } catch (error) {
         console.error("Error exchange Token:", error);
-        window.location.replace(window.location.origin + window.location.pathname);
+        setTokenStatus('failed');
+        if (Platform.OS === 'web' && typeof window !== 'undefined') {
+          window.location.replace(window.location.origin + window.location.pathname);
+        }
       }
     };
-  
+
     retrieveToken();
-  }, []);
+  }, [rawCode]);
 
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 }}>
-      <Text variant="headlineLarge" 
+      <Text variant="headlineLarge"
         style={{ alignItems: 'center', margin: 10}}>
         {tokenStatus === 'success' && i18n.t('github_auth_success')}
         {tokenStatus === 'failed' && i18n.t('github_auth_failed')}
       </Text>
-      <Button mode="elevated" onPress={() => window.close()}>Close</Button>
+      <Button mode="elevated" onPress={() => {
+        if (Platform.OS === 'web' && typeof window !== 'undefined') {
+          window.close();
+        }
+      }}>Close</Button>
     </View>
   );
 }

--- a/components/screens/SettingScreen.js
+++ b/components/screens/SettingScreen.js
@@ -1,22 +1,28 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import * as AuthSession from 'expo-auth-session';
 import { View, StyleSheet, Platform } from 'react-native';
-import { useRoute } from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/native';
 import { Appbar, List } from 'react-native-paper';
 import i18n from '../i18n/i18n';
-import { readData } from "../apis/StorageAPI";
+import {
+  exchangeToken,
+  ensureFreshGithubAuth,
+  hasValidGithubCredentials,
+  refreshGithubToken,
+  shouldRefreshGithubToken,
+} from "../apis/GitHubAPI";
 import Redirector from "../Redirector";
 
 const useProxy = Platform.select({ web: false, default: true });
 
 const githubClientId = 'cd019fec05aa5b74ad81';
 const redirectUri = AuthSession.makeRedirectUri({
-  useProxy: true,
+  useProxy,
   path: 'openroutes/githubauth',
 });
 
 export default function SettingScreen() {
-  const [githubToken, setGithubToken] = useState(null);
+  const [githubAuth, setGithubAuth] = useState(null);
   const [request, response, promptAsync] = AuthSession.useAuthRequest({
     clientId: githubClientId,
     scopes: ['identity', 'public_repo'],
@@ -24,36 +30,82 @@ export default function SettingScreen() {
   }, { authorizationEndpoint: 'https://github.com/login/oauth/authorize' });
 
   useEffect(() => {
-    if (response?.type === 'success') {
+    const handleAuthResponse = async () => {
+      if (response?.type !== 'success') {
+        return;
+      }
       const { code } = response.params;
-      console.log(code);
-    }
-  }, [response]);
+      if (!code) {
+        return;
+      }
 
-  const route = useRoute();
-  useEffect(() => {
-    const fetchToken = async () => {
-      const token = await readData('github_access_token');
-      if (token) {
-        setGithubToken(token);
+      try {
+        const auth = await exchangeToken(code);
+        setGithubAuth(auth);
+      } catch (error) {
+        console.error('Failed to exchange GitHub code:', error);
       }
     };
-    fetchToken();
-  }, [route]);
+
+    handleAuthResponse();
+  }, [response]);
+
+  useFocusEffect(
+    useCallback(() => {
+      let isActive = true;
+      const fetchAuth = async () => {
+        const stored = await ensureFreshGithubAuth();
+        if (isActive) {
+          setGithubAuth(stored);
+        }
+      };
+      fetchAuth();
+      return () => {
+        isActive = false;
+      };
+    }, [])
+  );
+
+  useEffect(() => {
+    const refreshIfNeeded = async () => {
+      if (!githubAuth) {
+        return;
+      }
+
+      if (shouldRefreshGithubToken(githubAuth) && githubAuth.refreshToken) {
+        try {
+          const refreshed = await refreshGithubToken(githubAuth);
+          setGithubAuth(refreshed);
+        } catch (error) {
+          console.error('Failed to refresh GitHub auth token:', error);
+        }
+      }
+    };
+
+    refreshIfNeeded();
+  }, [githubAuth]);
+  const isAuthenticated = hasValidGithubCredentials(githubAuth);
 
   return (
     <View style={styles.container}>
       <Redirector />
       <Appbar.Header elevation={2}>
         <Appbar.Content title={i18n.t('title_setting')} />
-        <Appbar.Action icon="github" color={githubToken ? "#4CAF50" : ""} />
+        <Appbar.Action icon="github" color={isAuthenticated ? "#4CAF50" : ""} />
       </Appbar.Header>
       <List.Section>
         <List.Subheader>{i18n.t('setting_account')}</List.Subheader>
         <List.Item
           left={(props) => <List.Icon {...props} icon="github" />}
           title={i18n.t('setting_github_oauth')}
-          onPress={() => {promptAsync()}}
+          onPress={() => {
+            if (!request) {
+              return;
+            }
+            promptAsync({
+              useProxy,
+            });
+          }}
         />
       </List.Section>
     </View>


### PR DESCRIPTION
## Summary
- persist GitHub OAuth responses with user profile data, refresh support, and helpers used by API calls
- update the GitHub auth, settings, home, and share screens to consume the shared auth state and drive the status indicators

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d20134ad748323832462a50fd9a2df