### PR TITLE
Fix GitHub OAuth redirect mismatch for Expo proxy

### DIFF
--- a/components/screens/GithubAuthScreen.js
+++ b/components/screens/GithubAuthScreen.js
@@ -1,47 +1,53 @@
 import React, { useEffect, useState } from 'react';
-import { View } from 'react-native';
-import { useRoute } from '@react-navigation/native';
+import { Platform, View } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
 import { Text, Button } from 'react-native-paper';
 import i18n from '../i18n/i18n';
-import { exchangeToken } from "../apis/GitHubAPI";
-import { readData } from "../apis/StorageAPI";
+import { exchangeToken, getStoredGithubAuth, hasValidGithubCredentials } from "../apis/GitHubAPI";
 
 export default function GithubAuthScreen() {
-  const route = useRoute();
+  const { code: rawCode } = useLocalSearchParams();
   const [tokenStatus, setTokenStatus] = useState('checking');
 
   useEffect(() => {
     const retrieveToken = async () => {
       try {
-        const code = route.params?.code ?? null;
+        const codeParam = Array.isArray(rawCode) ? rawCode[0] : rawCode;
+        const code = codeParam ?? null;
         if (code) {
-          await exchangeToken(code);
-          window.location.replace(window.location.origin + window.location.pathname);
-        } else {
-          const token = await readData('github_access_token');
-          if (token) {
-            setTokenStatus('success');
-          } else {
-            setTokenStatus('failed');
+          const auth = await exchangeToken(code);
+          setTokenStatus(hasValidGithubCredentials(auth) ? 'success' : 'failed');
+          if (Platform.OS === 'web' && typeof window !== 'undefined') {
+            window.location.replace(window.location.origin + window.location.pathname);
           }
+        } else {
+          const auth = await getStoredGithubAuth();
+          setTokenStatus(hasValidGithubCredentials(auth) ? 'success' : 'failed');
         }
       } catch (error) {
         console.error("Error exchange Token:", error);
-        window.location.replace(window.location.origin + window.location.pathname);
+        setTokenStatus('failed');
+        if (Platform.OS === 'web' && typeof window !== 'undefined') {
+          window.location.replace(window.location.origin + window.location.pathname);
+        }
       }
     };
-  
+
     retrieveToken();
-  }, []);
+  }, [rawCode]);
 
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 }}>
-      <Text variant="headlineLarge" 
+      <Text variant="headlineLarge"
         style={{ alignItems: 'center', margin: 10}}>
         {tokenStatus === 'success' && i18n.t('github_auth_success')}
         {tokenStatus === 'failed' && i18n.t('github_auth_failed')}
       </Text>
-      <Button mode="elevated" onPress={() => window.close()}>Close</Button>
+      <Button mode="elevated" onPress={() => {
+        if (Platform.OS === 'web' && typeof window !== 'undefined') {
+          window.close();
+        }
+      }}>Close</Button>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- allow the GitHub token exchange helper to accept a custom redirect URI instead of always using the GitHub Pages URL
- pass the Expo AuthSession redirect from the settings screen so proxy-based logins exchange tokens successfully

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d20134ad748323832462a50fd9a2df