### PR TITLE
Fix GitHub OAuth response handling

### DIFF
--- a/components/screens/SettingScreen.js
+++ b/components/screens/SettingScreen.js
@@ -34,7 +34,7 @@ export default function SettingScreen() {
 
   useEffect(() => {
     const handleAuthResponse = async () => {
-      if (!useProxy || response?.type !== 'success') {
+      if (response?.type !== 'success') {
         return;
       }
       const { code } = response.params;


### PR DESCRIPTION
## Summary
- allow GitHub OAuth responses to be processed on every platform by removing an erroneous proxy guard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d234bb8d7483238de692653cd485ee