### PR TITLE
feat: support configurable GitHub token persistence

### DIFF
--- a/components/apis/GitHubAPI.js
+++ b/components/apis/GitHubAPI.js
@@ -2,6 +2,9 @@ import yaml from 'js-yaml';
 import { storeData, deleteData, readData } from "./StorageAPI";
 
 const GITHUB_TOKEN_KEY = 'github_access_token';
+const GITHUB_REFRESH_TOKEN_KEY = 'github_refresh_token';
+const GITHUB_TOKEN_EXPIRY_KEY = 'github_access_token_expiry';
+const GITHUB_REFRESH_TOKEN_EXPIRY_KEY = 'github_refresh_token_expiry';
 const GITHUB_USER_KEY = 'github_user_profile';
 const GITHUB_REMEMBER_PREFERENCE_KEY = 'github_token_persistence_preference';
 
@@ -143,12 +146,20 @@ const createIssue = async (routeData, token) => {
   return resJson;
 }
 
-const exchangeToken = async (cd) => {
-  const ci = 'cd019fec05aa5b74ad81';
-  const sc = '51d66fda4e5184bcc7a4ceaf99f78a8cf3acb028';
-  const ru = 'https://yougikou.github.io/openroutes/githubauth';
-  const proxyUrl = 'https://cors-anywhere.azm.workers.dev/';
+const clientId = 'cd019fec05aa5b74ad81';
+const clientSecret = '51d66fda4e5184bcc7a4ceaf99f78a8cf3acb028';
+const redirectUri = 'https://yougikou.github.io/openroutes/githubauth';
+const proxyUrl = 'https://cors-anywhere.azm.workers.dev/';
 
+const calculateExpiry = (seconds) => {
+  if (!seconds || Number.isNaN(Number(seconds))) {
+    return null;
+  }
+  const expiresAt = new Date(Date.now() + Number(seconds) * 1000);
+  return expiresAt.toISOString();
+};
+
+const exchangeToken = async (cd) => {
   try {
     const response = await fetch(proxyUrl + 'https://github.com/login/oauth/access_token', {
       method: 'POST',
@@ -156,19 +167,75 @@ const exchangeToken = async (cd) => {
         'Content-Type': 'application/x-www-form-urlencoded',
         'Accept': 'application/json'
       },
-      body: `client_id=${ci}&client_secret=${sc}&code=${cd}&redirect_uri=${ru}`,
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code: cd,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code',
+      }).toString(),
     });
 
     const data = await response.json();
+    if (data.error) {
+      throw new Error(data.error_description || data.error || 'Unknown error exchanging token');
+    }
+
     if (data.access_token) {
-      return data.access_token;
+      return {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token ?? null,
+        expiresAt: calculateExpiry(data.expires_in),
+        refreshTokenExpiresAt: calculateExpiry(data.refresh_token_expires_in),
+        tokenType: data.token_type ?? null,
+        scope: data.scope ?? null,
+      };
     }
     throw new Error('No access token found in response');
   } catch (error) {
     console.error('Token exchange error:', error);
     throw error;
   }
-}
+};
+
+const refreshGithubAccessToken = async (refreshToken) => {
+  try {
+    const response = await fetch(proxyUrl + 'https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/json'
+      },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }).toString(),
+    });
+
+    const data = await response.json();
+    if (data.error) {
+      throw new Error(data.error_description || data.error || 'Unknown error refreshing token');
+    }
+
+    if (!data.access_token) {
+      throw new Error('No access token found in refresh response');
+    }
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token ?? refreshToken,
+      expiresAt: calculateExpiry(data.expires_in),
+      refreshTokenExpiresAt: calculateExpiry(data.refresh_token_expires_in),
+      tokenType: data.token_type ?? null,
+      scope: data.scope ?? null,
+    };
+  } catch (error) {
+    console.error('Token refresh error:', error);
+    throw error;
+  }
+};
 
 const fetchAuthenticatedUser = async (token) => {
   try {
@@ -196,24 +263,53 @@ const fetchAuthenticatedUser = async (token) => {
   }
 };
 
-const saveGithubCredentials = async ({ token, user }) => {
+const saveGithubCredentials = async (
+  { token, user, refreshToken, tokenExpiry, refreshTokenExpiry },
+  options = {},
+) => {
   try {
     if (token) {
-      await storeData(GITHUB_TOKEN_KEY, token);
+      await storeData(GITHUB_TOKEN_KEY, token, options);
+    } else {
+      await deleteData(GITHUB_TOKEN_KEY, options);
     }
+
+    if (refreshToken) {
+      await storeData(GITHUB_REFRESH_TOKEN_KEY, refreshToken, options);
+    } else {
+      await deleteData(GITHUB_REFRESH_TOKEN_KEY, options);
+    }
+
+    if (tokenExpiry) {
+      await storeData(GITHUB_TOKEN_EXPIRY_KEY, tokenExpiry, options);
+    } else {
+      await deleteData(GITHUB_TOKEN_EXPIRY_KEY, options);
+    }
+
+    if (refreshTokenExpiry) {
+      await storeData(GITHUB_REFRESH_TOKEN_EXPIRY_KEY, refreshTokenExpiry, options);
+    } else {
+      await deleteData(GITHUB_REFRESH_TOKEN_EXPIRY_KEY, options);
+    }
+
     if (user) {
-      await storeData(GITHUB_USER_KEY, JSON.stringify(user));
+      await storeData(GITHUB_USER_KEY, JSON.stringify(user), options);
+    } else {
+      await deleteData(GITHUB_USER_KEY, options);
     }
   } catch (error) {
     console.error('Error saving GitHub credentials:', error);
   }
 };
 
-const loadGithubCredentials = async () => {
+const loadGithubCredentials = async (options = {}) => {
   try {
-    const [token, userString] = await Promise.all([
-      readData(GITHUB_TOKEN_KEY),
-      readData(GITHUB_USER_KEY),
+    const [token, refreshToken, tokenExpiry, refreshTokenExpiry, userString] = await Promise.all([
+      readData(GITHUB_TOKEN_KEY, options),
+      readData(GITHUB_REFRESH_TOKEN_KEY, options),
+      readData(GITHUB_TOKEN_EXPIRY_KEY, options),
+      readData(GITHUB_REFRESH_TOKEN_EXPIRY_KEY, options),
+      readData(GITHUB_USER_KEY, options),
     ]);
 
     let user = null;
@@ -227,18 +323,26 @@ const loadGithubCredentials = async () => {
 
     return {
       token: token ?? null,
+      refreshToken: refreshToken ?? null,
+      tokenExpiry: tokenExpiry ?? null,
+      refreshTokenExpiry: refreshTokenExpiry ?? null,
       user: user ?? null,
     };
   } catch (error) {
     console.error('Error loading GitHub credentials:', error);
-    return { token: null, user: null };
+    return { token: null, refreshToken: null, tokenExpiry: null, refreshTokenExpiry: null, user: null };
   }
 };
 
-const clearGithubCredentials = async () => {
+const clearGithubCredentials = async (options = {}) => {
   try {
-    await deleteData(GITHUB_TOKEN_KEY);
-    await deleteData(GITHUB_USER_KEY);
+    await Promise.all([
+      deleteData(GITHUB_TOKEN_KEY, options),
+      deleteData(GITHUB_REFRESH_TOKEN_KEY, options),
+      deleteData(GITHUB_TOKEN_EXPIRY_KEY, options),
+      deleteData(GITHUB_REFRESH_TOKEN_EXPIRY_KEY, options),
+      deleteData(GITHUB_USER_KEY, options),
+    ]);
   } catch (error) {
     console.error('Error clearing GitHub credentials:', error);
   }
@@ -315,6 +419,7 @@ export {
   fetchIssues,
   createIssue,
   exchangeToken,
+  refreshGithubAccessToken,
   fetchAuthenticatedUser,
   saveGithubCredentials,
   loadGithubCredentials,

--- a/components/apis/StorageAPI.js
+++ b/components/apis/StorageAPI.js
@@ -1,29 +1,80 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-const storeData = async (key, value) => {
+const isWeb = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const resolveStorage = (persistent = true) => {
+  if (!isWeb) {
+    return null;
+  }
+
   try {
-    await AsyncStorage.setItem(key, value);
+    return persistent ? window.localStorage : window.sessionStorage;
   } catch (error) {
-    console.error("Error storing the data", error);
+    console.error('Error accessing web storage', error);
+    return null;
   }
 };
 
-const readData = async (key) => {
+const storeData = async (key, value, options = {}) => {
+  const { persistent = true } = options;
   try {
-    const value = await AsyncStorage.getItem(key);
-    return value
+    if (isWeb) {
+      const storage = resolveStorage(persistent);
+      if (!storage) {
+        return;
+      }
+      if (value === undefined || value === null) {
+        storage.removeItem(key);
+      } else {
+        storage.setItem(key, value);
+      }
+      return;
+    }
+
+    if (value === undefined || value === null) {
+      await AsyncStorage.removeItem(key);
+    } else {
+      await AsyncStorage.setItem(key, value);
+    }
   } catch (error) {
-    console.error("Error reading the data", error);
+    console.error('Error storing the data', error);
   }
 };
 
-const deleteData = async (key) => {
+const readData = async (key, options = {}) => {
+  const { persistent = true } = options;
   try {
+    if (isWeb) {
+      const storage = resolveStorage(persistent);
+      if (!storage) {
+        return null;
+      }
+      return storage.getItem(key);
+    }
+
+    return await AsyncStorage.getItem(key);
+  } catch (error) {
+    console.error('Error reading the data', error);
+    return null;
+  }
+};
+
+const deleteData = async (key, options = {}) => {
+  const { persistent = true } = options;
+  try {
+    if (isWeb) {
+      const storage = resolveStorage(persistent);
+      if (!storage) {
+        return;
+      }
+      storage.removeItem(key);
+      return;
+    }
+
     await AsyncStorage.removeItem(key);
   } catch (error) {
-    console.error("Error deleting the data", error);
+    console.error('Error deleting the data', error);
   }
 };
-
 
 export { storeData, readData, deleteData };

--- a/components/contexts/GithubAuthContext.js
+++ b/components/contexts/GithubAuthContext.js
@@ -3,6 +3,7 @@ import {
   clearGithubCredentials,
   loadGithubCredentials,
   loadRememberPreference,
+  refreshGithubAccessToken,
   saveGithubCredentials,
   saveRememberPreference,
 } from '../apis/GitHubAPI';
@@ -11,65 +12,216 @@ const GithubAuthContext = createContext(undefined);
 
 export const GithubAuthProvider = ({ children }) => {
   const [token, setToken] = useState(null);
+  const [refreshToken, setRefreshToken] = useState(null);
+  const [tokenExpiry, setTokenExpiry] = useState(null);
+  const [refreshTokenExpiry, setRefreshTokenExpiry] = useState(null);
   const [user, setUser] = useState(null);
   const [shouldPersistToken, setShouldPersistTokenState] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
+
+  const ensureValidCredentials = useCallback(async (credentials, storageOptions) => {
+    const sanitised = {
+      token: credentials?.token ?? null,
+      refreshToken: credentials?.refreshToken ?? null,
+      tokenExpiry: credentials?.tokenExpiry ?? null,
+      refreshTokenExpiry: credentials?.refreshTokenExpiry ?? null,
+      user: credentials?.user ?? null,
+    };
+
+    if (!sanitised.token || !sanitised.user || !sanitised.user.id) {
+      return sanitised;
+    }
+
+    const tokenExpiryTime = sanitised.tokenExpiry ? Date.parse(sanitised.tokenExpiry) : null;
+    if (tokenExpiryTime === null || Number.isNaN(tokenExpiryTime) || tokenExpiryTime > Date.now()) {
+      return sanitised;
+    }
+
+    if (!storageOptions?.persistent) {
+      await clearGithubCredentials(storageOptions);
+      return {
+        token: null,
+        refreshToken: null,
+        tokenExpiry: null,
+        refreshTokenExpiry: null,
+        user: null,
+      };
+    }
+
+    const refreshExpiryTime = sanitised.refreshTokenExpiry ? Date.parse(sanitised.refreshTokenExpiry) : null;
+    if (!sanitised.refreshToken || (refreshExpiryTime !== null && !Number.isNaN(refreshExpiryTime) && refreshExpiryTime <= Date.now())) {
+      await clearGithubCredentials(storageOptions);
+      return {
+        token: null,
+        refreshToken: null,
+        tokenExpiry: null,
+        refreshTokenExpiry: null,
+        user: null,
+      };
+    }
+
+    try {
+      const refreshed = await refreshGithubAccessToken(sanitised.refreshToken);
+      const nextCredentials = {
+        token: refreshed.accessToken,
+        refreshToken: refreshed.refreshToken ?? sanitised.refreshToken,
+        tokenExpiry: refreshed.expiresAt ?? null,
+        refreshTokenExpiry: refreshed.refreshTokenExpiresAt ?? sanitised.refreshTokenExpiry ?? null,
+        user: sanitised.user,
+      };
+      await saveGithubCredentials(nextCredentials, storageOptions);
+      return nextCredentials;
+    } catch (error) {
+      console.error('Failed to refresh stored GitHub token:', error);
+      await clearGithubCredentials(storageOptions);
+      return {
+        token: null,
+        refreshToken: null,
+        tokenExpiry: null,
+        refreshTokenExpiry: null,
+        user: null,
+      };
+    }
+  }, [clearGithubCredentials, refreshGithubAccessToken, saveGithubCredentials]);
 
   useEffect(() => {
     const initialise = async () => {
       const preference = await loadRememberPreference();
       setShouldPersistTokenState(preference);
 
-      const { token: storedToken, user: storedUser } = await loadGithubCredentials();
-      if (storedToken && storedUser && storedUser.id) {
-        setToken(storedToken);
-        setUser(storedUser);
+      const sessionCredentials = await loadGithubCredentials({ persistent: false });
+      const persistentCredentials = await loadGithubCredentials({ persistent: true });
+
+      let activeCredentials = preference ? persistentCredentials : sessionCredentials;
+      let activeStorage = preference ? { persistent: true } : { persistent: false };
+
+      if ((!activeCredentials?.token || !activeCredentials?.user?.id) && sessionCredentials?.token && sessionCredentials?.user?.id) {
+        activeCredentials = sessionCredentials;
+        activeStorage = { persistent: false };
+      }
+
+      const validated = await ensureValidCredentials(activeCredentials, activeStorage);
+
+      let finalCredentials = validated;
+      let finalStorage = activeStorage;
+
+      if (
+        (!finalCredentials || !finalCredentials.token || !finalCredentials.user?.id) &&
+        activeStorage?.persistent &&
+        sessionCredentials?.token &&
+        sessionCredentials?.user?.id
+      ) {
+        finalCredentials = await ensureValidCredentials(sessionCredentials, { persistent: false });
+        finalStorage = { persistent: false };
+      }
+
+      if (finalCredentials && finalCredentials.token && finalCredentials.user && finalCredentials.user.id) {
+        setToken(finalCredentials.token);
+        setRefreshToken(finalCredentials.refreshToken ?? null);
+        setTokenExpiry(finalCredentials.tokenExpiry ?? null);
+        setRefreshTokenExpiry(finalCredentials.refreshTokenExpiry ?? null);
+        setUser(finalCredentials.user);
+      } else {
+        setToken(null);
+        setRefreshToken(null);
+        setTokenExpiry(null);
+        setRefreshTokenExpiry(null);
+        setUser(null);
+      }
+
+      if (finalStorage?.persistent) {
         setShouldPersistTokenState(true);
       }
+
       setHasLoaded(true);
     };
 
     initialise();
-  }, []);
+  }, [ensureValidCredentials]);
 
   const applyPersistencePreference = useCallback(async (nextShouldPersist) => {
     setShouldPersistTokenState(nextShouldPersist);
     await saveRememberPreference(nextShouldPersist);
 
+    const credentialPayload = {
+      token,
+      user,
+      refreshToken,
+      tokenExpiry,
+      refreshTokenExpiry,
+    };
+
     if (!token || !user || !user.id) {
-      if (!nextShouldPersist) {
-        await clearGithubCredentials();
+      if (nextShouldPersist) {
+        await clearGithubCredentials({ persistent: false });
+      } else {
+        await clearGithubCredentials({ persistent: true });
       }
       return;
     }
 
     if (nextShouldPersist) {
-      await saveGithubCredentials({ token, user });
+      await saveGithubCredentials(credentialPayload, { persistent: true });
+      await clearGithubCredentials({ persistent: false });
     } else {
-      await clearGithubCredentials();
+      await saveGithubCredentials(credentialPayload, { persistent: false });
+      await clearGithubCredentials({ persistent: true });
     }
-  }, [token, user]);
+  }, [
+    token,
+    user,
+    refreshToken,
+    tokenExpiry,
+    refreshTokenExpiry,
+    clearGithubCredentials,
+    saveGithubCredentials,
+    saveRememberPreference,
+  ]);
 
-  const signIn = useCallback(async ({ token: nextToken, user: nextUser, rememberToken }) => {
+  const signIn = useCallback(async ({
+    token: nextToken,
+    user: nextUser,
+    refreshToken: nextRefreshToken = null,
+    tokenExpiry: nextTokenExpiry = null,
+    refreshTokenExpiry: nextRefreshTokenExpiry = null,
+    rememberToken,
+  }) => {
     setToken(nextToken);
+    setRefreshToken(nextRefreshToken);
+    setTokenExpiry(nextTokenExpiry);
+    setRefreshTokenExpiry(nextRefreshTokenExpiry);
     setUser(nextUser);
 
     const persist = rememberToken ?? shouldPersistToken;
     setShouldPersistTokenState(persist);
     await saveRememberPreference(persist);
 
+    const credentialPayload = {
+      token: nextToken,
+      user: nextUser,
+      refreshToken: nextRefreshToken,
+      tokenExpiry: nextTokenExpiry,
+      refreshTokenExpiry: nextRefreshTokenExpiry,
+    };
+
     if (persist) {
-      await saveGithubCredentials({ token: nextToken, user: nextUser });
+      await saveGithubCredentials(credentialPayload, { persistent: true });
+      await clearGithubCredentials({ persistent: false });
     } else {
-      await clearGithubCredentials();
+      await saveGithubCredentials(credentialPayload, { persistent: false });
+      await clearGithubCredentials({ persistent: true });
     }
-  }, [shouldPersistToken]);
+  }, [shouldPersistToken, saveRememberPreference, saveGithubCredentials, clearGithubCredentials]);
 
   const signOut = useCallback(async () => {
     setToken(null);
+    setRefreshToken(null);
+    setTokenExpiry(null);
+    setRefreshTokenExpiry(null);
     setUser(null);
-    await clearGithubCredentials();
-  }, []);
+    await clearGithubCredentials({ persistent: true });
+    await clearGithubCredentials({ persistent: false });
+  }, [clearGithubCredentials]);
 
   const value = useMemo(() => ({
     token,

--- a/components/screens/GithubAuthScreen.js
+++ b/components/screens/GithubAuthScreen.js
@@ -47,9 +47,16 @@ export default function GithubAuthScreen() {
           return;
         }
 
-        const token = await exchangeToken(code);
-        const userProfile = await fetchAuthenticatedUser(token);
-        await signIn({ token, user: userProfile, rememberToken: shouldPersistToken });
+        const tokenPayload = await exchangeToken(code);
+        const userProfile = await fetchAuthenticatedUser(tokenPayload.accessToken);
+        await signIn({
+          token: tokenPayload.accessToken,
+          refreshToken: tokenPayload.refreshToken,
+          tokenExpiry: tokenPayload.expiresAt,
+          refreshTokenExpiry: tokenPayload.refreshTokenExpiresAt,
+          user: userProfile,
+          rememberToken: shouldPersistToken,
+        });
 
         if (!isCancelled) {
           setTokenStatus('success');


### PR DESCRIPTION
## Summary
- update the shared storage helper to support web session and local storage buckets
- persist GitHub OAuth credentials with refresh metadata and refresh expired saved tokens when possible
- adjust the auth screens to consume the richer token payload and request offline access when saving tokens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d23f2783f483238ed05bba23b691f6