### PR TITLE
Fix GitHub OAuth redirect handling

### DIFF
--- a/components/apis/GitHubAPI.js
+++ b/components/apis/GitHubAPI.js
@@ -148,7 +148,7 @@ const createIssue = async (routeData, token) => {
 
 const clientId = 'cd019fec05aa5b74ad81';
 const clientSecret = '51d66fda4e5184bcc7a4ceaf99f78a8cf3acb028';
-const redirectUri = 'https://yougikou.github.io/openroutes/githubauth';
+const defaultRedirectUri = 'https://yougikou.github.io/openroutes/githubauth';
 const proxyUrl = 'https://cors-anywhere.azm.workers.dev/';
 
 const calculateExpiry = (seconds) => {
@@ -159,8 +159,9 @@ const calculateExpiry = (seconds) => {
   return expiresAt.toISOString();
 };
 
-const exchangeToken = async (cd) => {
+const exchangeToken = async (cd, options = {}) => {
   try {
+    const redirectUri = options.redirectUri ?? defaultRedirectUri;
     const response = await fetch(proxyUrl + 'https://github.com/login/oauth/access_token', {
       method: 'POST',
       headers: {

--- a/components/screens/GithubAuthScreen.js
+++ b/components/screens/GithubAuthScreen.js
@@ -47,7 +47,10 @@ export default function GithubAuthScreen() {
           return;
         }
 
-        const tokenPayload = await exchangeToken(code);
+        const redirectUri = typeof window !== 'undefined'
+          ? `${window.location.origin}${window.location.pathname}`
+          : undefined;
+        const tokenPayload = await exchangeToken(code, { redirectUri });
         const userProfile = await fetchAuthenticatedUser(tokenPayload.accessToken);
         await signIn({
           token: tokenPayload.accessToken,

--- a/components/screens/SettingScreen.js
+++ b/components/screens/SettingScreen.js
@@ -43,7 +43,7 @@ export default function SettingScreen() {
       }
 
       try {
-        const tokenPayload = await exchangeToken(code);
+        const tokenPayload = await exchangeToken(code, { redirectUri });
         const profile = await fetchAuthenticatedUser(tokenPayload.accessToken);
         await signIn({
           token: tokenPayload.accessToken,


### PR DESCRIPTION
## Summary
- allow GitHub token exchange to accept a caller-provided redirect URI so it matches the authorization request
- forward the computed redirect URI from the settings flow when exchanging authorization codes
- use the active browser location in the GitHub OAuth callback screen to ensure the redirect URI matches the one used by GitHub

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d24492c390832389bc8ec45796a261