### PR TITLE
Fix GitHub OAuth redirect on GitHub Pages

### DIFF
--- a/components/Redirector.js
+++ b/components/Redirector.js
@@ -1,15 +1,48 @@
-import React from 'react';
-import { Redirect } from 'expo-router';
+import { useEffect } from 'react';
+
+const STORAGE_KEY = 'openroutes:pendingPathRedirect';
+
+const normalizePath = (path) => {
+  if (!path) {
+    return '/openroutes/';
+  }
+
+  const hasOriginPrefix = path.startsWith('/openroutes');
+  const sanitizedPath = hasOriginPrefix ? path : `/openroutes${path.startsWith('/') ? path : `/${path}`}`;
+
+  return sanitizedPath;
+};
 
 const Redirector = () => {
-  if (process.env.NODE_ENV === 'production') {
-    const currentPath = window.location.pathname;
-    if (!currentPath.startsWith("/openroutes")) {
-      const newPath = `/openroutes/${currentPath}`;
-      return <Redirect href={newPath} />;
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
     }
-  }
-  return null
+
+    const pendingRedirect = window.sessionStorage?.getItem(STORAGE_KEY);
+    if (pendingRedirect) {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+      const targetPath = normalizePath(pendingRedirect);
+      const currentLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (targetPath !== currentLocation) {
+        window.history.replaceState(null, '', targetPath);
+      }
+      return;
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+      const currentPath = window.location.pathname;
+      if (!currentPath.startsWith('/openroutes')) {
+        const newPath = normalizePath(currentPath);
+        const nextUrl = `${newPath}${window.location.search}${window.location.hash}`;
+        if (nextUrl !== `${currentPath}${window.location.search}${window.location.hash}`) {
+          window.history.replaceState(null, '', nextUrl);
+        }
+      }
+    }
+  }, []);
+
+  return null;
 };
 
 export default Redirector;

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Redirecting…</title>
+    <script>
+      (function () {
+        var storageKey = 'openroutes:pendingPathRedirect';
+        try {
+          var redirectPath = window.location.pathname + window.location.search + window.location.hash;
+          sessionStorage.setItem(storageKey, redirectPath);
+        } catch (error) {
+          console.warn('Unable to persist redirect path', error);
+        }
+        window.location.replace('/openroutes/');
+      })();
+    </script>
+  </head>
+  <body>
+    <noscript>
+      <p>This site requires JavaScript to redirect you to the correct page.</p>
+      <p><a href="/openroutes/">Continue to OpenRoutes</a></p>
+    </noscript>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a GitHub Pages 404 fallback that preserves OAuth return parameters and redirects to the SPA entrypoint
- update the Redirector helper to restore stored paths and normalize the /openroutes prefix in production builds

## Testing
- yarn test *(fails: missing jest-environment-jsdom and react-native-worklets/plugin in the environment)*
- npm run web *(fails: Metro bundler cannot resolve react-native-worklets/plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d800b89b088323935c293c32918250