### PR TITLE
Add GitHub OAuth module with CLI and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# GitHub OAuth App configuration
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_REDIRECT_URI=http://localhost:3000/api/auth/github/callback
+# Comma separated scopes, defaults to read:user,user:email,public_repo,repo:status
+GITHUB_DEFAULT_SCOPES=
+# Set to true to automatically include repo scope for private repositories
+GITHUB_ALLOW_PRIVATE_REPO=false
+
+# Integration tests
+TEST_OWNER=
+TEST_REPO=
+GITHUB_TEST_TOKEN=

--- a/README.md
+++ b/README.md
@@ -40,3 +40,70 @@
 - 言語の切り替え改善
 - 継続コードのリファクタ（Typescriptへの書き換え．．．）
 - Open Mapサービスを利用して、ルートの地図描画するなど．．．
+
+## GitHub OAuth & Issues Integration
+
+This repository now ships with a reusable GitHub authentication layer that supports both Authorization Code and Device Flow, secure token persistence, and a typed API client for working with repositories and issues.
+
+### 1. Create a GitHub OAuth App
+
+1. Visit [GitHub Developer Settings](https://github.com/settings/developers) and create a new **OAuth App**.
+2. Set the callback URL to match your deployment. For local testing you can use `http://localhost:3000/api/auth/github/callback`.
+3. Copy the generated **Client ID** and **Client Secret**.
+
+Populate a `.env` file based on `.env.example`:
+
+```
+GITHUB_CLIENT_ID=<client-id>
+GITHUB_CLIENT_SECRET=<client-secret>
+GITHUB_REDIRECT_URI=http://localhost:3000/api/auth/github/callback
+GITHUB_DEFAULT_SCOPES=read:user,user:email,public_repo,repo:status
+TEST_OWNER=<repo-owner>
+TEST_REPO=<repo-name>
+```
+
+Set `GITHUB_ALLOW_PRIVATE_REPO=true` when you need full private-repository access (adds the `repo` scope automatically).
+
+### 2. CLI Smoke Tests
+
+The TypeScript CLI (`src/cli/index.ts`) orchestrates the complete device-flow experience and offers health checks:
+
+```bash
+npm run auth:start     # 自动选择授权方式 (设备码优先)
+npm run auth:whoami    # 查看当前账号与 scope
+npm run test:repo      # 在 TEST_OWNER/TEST_REPO 上跑通 Issue 全流程
+npm run auth:revoke    # 撤销并清理本地凭证
+```
+
+During CI you can skip interactive auth by injecting `GITHUB_TEST_TOKEN` (optionally with `GITHUB_TEST_LOGIN`, `GITHUB_TEST_USER_ID`, `GITHUB_TEST_SCOPES`).
+
+### 3. Programmatic Usage
+
+```ts
+import { GitHubOAuth, createGitHubClient, createSecureStorage } from './src/github';
+
+const storage = createSecureStorage();
+const oauth = new GitHubOAuth({ storage });
+const client = createGitHubClient({ storage });
+
+// Start auth (web uses Authorization Code; Node/CLI falls back to Device Flow)
+const start = await oauth.startAuthorization();
+
+// After completing auth, call the GitHub Issues APIs
+await client.createIssue('owner', 'repo', { title: 'New issue', body: '内容' });
+```
+
+### 4. Testing
+
+Run unit tests and optional integration checks with Jest:
+
+```bash
+npm run test:unit
+npm run test:integration   # requires GITHUB_TEST_TOKEN
+```
+
+The OAuth state machine, storage layer, retry/error handling, and repository access checks are all validated automatically.
+
+### 5. Personal Access Token fallback (optional)
+
+If you prefer using a fine-grained PAT, paste the token into `.env` as `GITHUB_TEST_TOKEN` and run `npm run auth:whoami`. The same storage, health checks, and revoke commands apply.

--- a/__tests__/integration/github.integration.test.ts
+++ b/__tests__/integration/github.integration.test.ts
@@ -1,0 +1,32 @@
+import { GitHubClient } from '../../src/github/client';
+import { InMemorySecureStorage } from '../../src/github/storage';
+import type { StoredAccount } from '../../src/github/types';
+
+declare const process: NodeJS.Process;
+
+const token = process.env.GITHUB_TEST_TOKEN;
+
+(token ? describe : describe.skip)('GitHub integration', () => {
+  const storage = new InMemorySecureStorage();
+  const account: StoredAccount = {
+    userId: Number(process.env.GITHUB_TEST_USER_ID || '0'),
+    login: process.env.GITHUB_TEST_LOGIN || 'integration',
+    avatarUrl: '',
+    accessToken: token!,
+    scopes: (process.env.GITHUB_TEST_SCOPES || 'repo').split(',').map((s) => s.trim()),
+    tokenType: 'token',
+    createdAt: new Date().toISOString(),
+  };
+
+  beforeAll(async () => {
+    await storage.saveAccount(account);
+  });
+
+  it('fetches current user and rate limits', async () => {
+    const client = new GitHubClient({ storage });
+    const who = await client.checkToken();
+    expect(who.user.login).toBeTruthy();
+    const limits = await client.checkRateLimit();
+    expect(limits.core.limit).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -1,0 +1,88 @@
+import { GitHubClient } from '../../src/github/client';
+import { InMemorySecureStorage } from '../../src/github/storage';
+import { TokenRevokedError, InsufficientScopeError, ResourceNotFoundError, ValidationError } from '../../src/github/errors';
+
+const account = {
+  userId: 1,
+  login: 'demo',
+  avatarUrl: 'avatar',
+  accessToken: 'token',
+  scopes: ['read:user'],
+  tokenType: 'token',
+  createdAt: new Date().toISOString(),
+};
+
+const jsonResponse = (status: number, body: any) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('GitHubClient', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  const setup = async (responses: Response[]) => {
+    const fetchMock = jest.fn();
+    responses.forEach((response) => fetchMock.mockResolvedValueOnce(response));
+    const storage = new InMemorySecureStorage();
+    await storage.saveAccount(account);
+    return { client: new GitHubClient({ storage, fetchImpl: fetchMock }), fetchMock };
+  };
+
+  it('adds authorization header on requests', async () => {
+    const { client, fetchMock } = await setup([
+      jsonResponse(200, []),
+    ]);
+    await client.listRepos();
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/user/repos'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `${account.tokenType} ${account.accessToken}` }),
+      })
+    );
+  });
+
+  it('retries on 500 errors', async () => {
+    const { client, fetchMock } = await setup([
+      jsonResponse(500, { message: 'server error' }),
+      jsonResponse(200, []),
+    ]);
+    await client.listRepos();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws TokenRevokedError on 401', async () => {
+    const { client } = await setup([
+      jsonResponse(401, { message: 'Bad credentials' }),
+    ]);
+    await expect(client.listRepos()).rejects.toBeInstanceOf(TokenRevokedError);
+  });
+
+  it('throws InsufficientScopeError on 403 integration error', async () => {
+    const { client } = await setup([
+      jsonResponse(403, { message: 'Resource not accessible by integration' }),
+    ]);
+    await expect(client.listRepos()).rejects.toBeInstanceOf(InsufficientScopeError);
+  });
+
+  it('throws ResourceNotFoundError on 404', async () => {
+    const { client } = await setup([
+      jsonResponse(404, { message: 'Not Found' }),
+    ]);
+    await expect(client.listRepos()).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('throws ValidationError on 422', async () => {
+    const { client } = await setup([
+      jsonResponse(422, { message: 'Validation Failed', errors: [{ field: 'title' }] }),
+    ]);
+    await expect(client.createIssue('owner', 'repo', { title: '' })).rejects.toBeInstanceOf(ValidationError);
+  });
+});

--- a/__tests__/unit/oauth.test.ts
+++ b/__tests__/unit/oauth.test.ts
@@ -1,0 +1,124 @@
+import { MemorySessionStateStore } from '../../src/github/sessionStore';
+import { GitHubOAuth, DeviceFlowSlowDownError, DeviceFlowPendingError } from '../../src/github/oauth';
+import { InMemorySecureStorage } from '../../src/github/storage';
+import type { DeviceFlowStart, OAuthConfig } from '../../src/github/types';
+
+const config: OAuthConfig = {
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  redirectUri: 'https://example.com/callback',
+  defaultScopes: ['read:user'],
+};
+
+const createResponse = (status: number, body: any) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'X-OAuth-Scopes': 'read:user' },
+  });
+
+describe('GitHubOAuth', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns device flow when no browser is available', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      createResponse(200, {
+        device_code: 'device-code',
+        user_code: 'user-code',
+        verification_uri: 'https://github.com/login/device',
+        expires_in: 900,
+        interval: 5,
+      })
+    );
+    const oauth = new GitHubOAuth({
+      config,
+      storage: new InMemorySecureStorage(),
+      sessionStore: new MemorySessionStateStore(),
+      fetchImpl: fetchMock,
+    });
+    const start = await oauth.startAuthorization({ browserAvailable: false });
+    expect(start.flow).toBe('device');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('validates state during authorization code callback', async () => {
+    const oauth = new GitHubOAuth({
+      config,
+      storage: new InMemorySecureStorage(),
+      sessionStore: new MemorySessionStateStore(),
+      fetchImpl: jest.fn(),
+    });
+    await expect(oauth.handleAuthorizationCodeCallback('code', 'invalid')).rejects.toThrow('State 校验失败');
+  });
+
+  it('exchanges authorization code and stores account', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(createResponse(200, { access_token: 'token', token_type: 'bearer', scope: 'read:user' }))
+      .mockResolvedValueOnce(createResponse(200, { id: 1, login: 'demo', avatar_url: 'https://avatar' }));
+    const storage = new InMemorySecureStorage();
+    const sessionStore = new MemorySessionStateStore();
+    const oauth = new GitHubOAuth({ config, storage, sessionStore, fetchImpl: fetchMock });
+    await sessionStore.setState('state', Date.now() + 10_000);
+    const result = await oauth.handleAuthorizationCodeCallback('code', 'state');
+    expect(result.user.login).toBe('demo');
+    const account = await storage.getAccount();
+    expect(account?.login).toBe('demo');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles device flow pending and success', async () => {
+    jest.useFakeTimers();
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(createResponse(200, { error: 'authorization_pending' }))
+      .mockResolvedValueOnce(createResponse(200, { access_token: 'token', token_type: 'bearer', scope: 'read:user' }))
+      .mockResolvedValueOnce(createResponse(200, { id: 1, login: 'demo', avatar_url: 'avatar' }));
+    const storage = new InMemorySecureStorage();
+    const oauth = new GitHubOAuth({ config, storage, sessionStore: new MemorySessionStateStore(), fetchImpl: fetchMock });
+    const start: DeviceFlowStart = {
+      flow: 'device',
+      deviceCode: 'device',
+      userCode: 'user',
+      verificationUri: 'https://github.com/login/device',
+      expiresIn: 600,
+      interval: 1,
+      scopes: ['read:user'],
+    };
+    const promise = oauth.waitForDeviceToken(start);
+    await jest.advanceTimersByTimeAsync(1000);
+    await jest.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+    expect(result.user.login).toBe('demo');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws specialized errors for device flow edge cases', async () => {
+    const pendingFetch = jest.fn().mockResolvedValue(createResponse(200, { error: 'authorization_pending' }));
+    const oauthPending = new GitHubOAuth({ config, storage: new InMemorySecureStorage(), sessionStore: new MemorySessionStateStore(), fetchImpl: pendingFetch });
+    await expect((oauthPending as any).exchangeDeviceCode('device')).rejects.toBeInstanceOf(DeviceFlowPendingError);
+
+    const slowFetch = jest.fn().mockResolvedValue(createResponse(200, { error: 'slow_down' }));
+    const oauthSlow = new GitHubOAuth({ config, storage: new InMemorySecureStorage(), sessionStore: new MemorySessionStateStore(), fetchImpl: slowFetch });
+    await expect((oauthSlow as any).exchangeDeviceCode('device')).rejects.toBeInstanceOf(DeviceFlowSlowDownError);
+
+    const expiredFetch = jest.fn().mockResolvedValue(createResponse(200, { error: 'expired_token' }));
+    const oauthExpired = new GitHubOAuth({ config, storage: new InMemorySecureStorage(), sessionStore: new MemorySessionStateStore(), fetchImpl: expiredFetch });
+    await expect((oauthExpired as any).exchangeDeviceCode('device')).rejects.toThrow('设备码过期');
+
+    const deniedFetch = jest.fn().mockResolvedValue(createResponse(200, { error: 'access_denied' }));
+    const oauthDenied = new GitHubOAuth({ config, storage: new InMemorySecureStorage(), sessionStore: new MemorySessionStateStore(), fetchImpl: deniedFetch });
+    await expect((oauthDenied as any).exchangeDeviceCode('device')).rejects.toThrow('用户拒绝了授权请求');
+  });
+});

--- a/__tests__/unit/storage.test.ts
+++ b/__tests__/unit/storage.test.ts
@@ -1,0 +1,31 @@
+import { InMemorySecureStorage } from '../../src/github/storage';
+
+const sampleAccount = {
+  userId: 1,
+  login: 'demo',
+  avatarUrl: 'avatar',
+  accessToken: 'token',
+  scopes: ['read:user'],
+  tokenType: 'bearer',
+  createdAt: new Date().toISOString(),
+};
+
+describe('InMemorySecureStorage', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('saves and retrieves account', async () => {
+    const storage = new InMemorySecureStorage();
+    await storage.saveAccount(sampleAccount);
+    const result = await storage.getAccount();
+    expect(result).toEqual(sampleAccount);
+    await storage.clear();
+    expect(await storage.getAccount()).toBeNull();
+  });
+});
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,11 @@
 module.exports = {
   testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]sx?$': 'babel-jest',
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+    '^.+\\.[j]sx?$': 'babel-jest',
   },
-  testMatch: ['**/__tests__/**/*.test.js'],
-  moduleFileExtensions: ['js', 'jsx'],
+  testMatch: ['**/__tests__/**/*.test.(ts|tsx|js)'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  setupFiles: ['dotenv/config'],
+  collectCoverageFrom: ['src/**/*.{ts,tsx,js,jsx}'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@react-navigation/stack": "^7.4.8",
         "@shopify/flash-list": "2.0.3",
         "@turf/turf": "^7.2.0",
+        "dotenv": "^17.2.2",
         "expo": "^54.0.10",
         "expo-constants": "~18.0.9",
         "expo-dev-client": "~6.0.12",
@@ -30,7 +31,9 @@
         "expo-status-bar": "~3.0.8",
         "geojson-to-kml": "^0.0.1",
         "i18n-js": "^4.5.1",
+        "idb-keyval": "^6.2.2",
         "js-yaml": "^4.1.0",
+        "keytar": "^7.9.0",
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-native": "0.81.4",
@@ -43,16 +46,22 @@
         "react-native-screens": "~4.16.0",
         "react-native-web": "^0.21.1",
         "react-native-worklets": "^0.6.0",
-        "togpx": "^0.5.4"
+        "togpx": "^0.5.4",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@babel/core": "^7.28.4",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.2.0",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^24.5.2",
         "babel-jest": "^29.7.0",
         "gh-pages": "^6.3.0",
         "jest": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0"
+        "jest-environment-jsdom": "^29.7.0",
+        "ts-jest": "^29.4.4",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1620,6 +1629,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
@@ -1901,6 +1934,18 @@
         "getenv": "^2.0.0"
       }
     },
+    "node_modules/@expo/env/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@expo/fingerprint": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.1.tgz",
@@ -2079,6 +2124,18 @@
         "expo": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@expo/metro-runtime": {
@@ -2525,6 +2582,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2584,6 +2651,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -2598,6 +2675,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -4087,6 +4188,34 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@turf/along": {
       "version": "7.2.0",
@@ -6214,6 +6343,237 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz",
+      "integrity": "sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
+      "integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
+      "integrity": "sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.1.2",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.1.2",
+        "jest-message-util": "30.1.0",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.1.0.tgz",
+      "integrity": "sha512-HizKDGG98cYkWmaLUHChq4iN+oCENohQLb7Z5guBPumYs+/etonmNFlg1Ps6yN9LTPyZn+M+b/9BbnHx3WTMDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.0.5",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.0.5",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
+      "integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
+      "integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -6227,12 +6587,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6249,9 +6609,9 @@
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -6833,6 +7193,17 @@
         "node": "*"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/bops": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
@@ -6882,12 +7253,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -6924,6 +7295,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -7501,6 +7885,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
@@ -7675,6 +8066,21 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
@@ -7793,6 +8199,16 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -7848,9 +8264,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -7867,6 +8283,18 @@
       "dependencies": {
         "dotenv": "^16.4.5"
       },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -7946,6 +8374,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -8218,6 +8655,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expect": {
@@ -8743,9 +9189,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -8892,6 +9338,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.2.0",
@@ -9106,6 +9558,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -9190,6 +9648,45 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/handlebars/node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -9414,6 +9911,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -10783,6 +11286,17 @@
         "xmldom": "^0.1.21"
       }
     },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -11096,6 +11610,13 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -11231,6 +11752,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/make-plural": {
       "version": "7.3.0",
@@ -11646,12 +12174,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -11712,6 +12240,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -11769,6 +12309,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -11804,6 +12350,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -11820,10 +12372,47 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nested-error-stacks": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -12488,6 +13077,32 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -12583,6 +13198,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -13848,6 +14473,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-plist": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz",
@@ -14330,6 +15000,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -14637,11 +15341,153 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
+      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -14667,6 +15513,20 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ua-parser-js": {
       "version": "1.0.37",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
@@ -14690,6 +15550,20 @@
         "node": "*"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici": {
       "version": "6.21.3",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
@@ -14700,9 +15574,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -14907,6 +15781,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -15383,6 +16264,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
     "web": "expo start --web",
     "deploy": "gh-pages -t -d dist",
     "predeploy": "expo export -p web",
-    "test": "jest"
+    "build": "tsc",
+    "test": "jest --runInBand",
+    "test:unit": "jest __tests__/unit --runInBand",
+    "test:integration": "jest __tests__/integration --runInBand",
+    "auth:start": "ts-node src/cli/index.ts auth:start",
+    "auth:whoami": "ts-node src/cli/index.ts auth:whoami",
+    "test:repo": "ts-node src/cli/index.ts test:repo",
+    "auth:revoke": "ts-node src/cli/index.ts auth:revoke"
   },
   "dependencies": {
     "@mapbox/togeojson": "^0.16.2",
@@ -22,6 +29,7 @@
     "@react-navigation/stack": "^7.4.8",
     "@shopify/flash-list": "2.0.3",
     "@turf/turf": "^7.2.0",
+    "dotenv": "^17.2.2",
     "expo": "^54.0.10",
     "expo-constants": "~18.0.9",
     "expo-dev-client": "~6.0.12",
@@ -34,7 +42,9 @@
     "expo-status-bar": "~3.0.8",
     "geojson-to-kml": "^0.0.1",
     "i18n-js": "^4.5.1",
+    "idb-keyval": "^6.2.2",
     "js-yaml": "^4.1.0",
+    "keytar": "^7.9.0",
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "react-native": "0.81.4",
@@ -47,16 +57,22 @@
     "react-native-screens": "~4.16.0",
     "react-native-web": "^0.21.1",
     "react-native-worklets": "^0.6.0",
-    "togpx": "^0.5.4"
+    "togpx": "^0.5.4",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.2.0",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^24.5.2",
     "babel-jest": "^29.7.0",
     "gh-pages": "^6.3.0",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.4.4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env ts-node
+import dotenv from 'dotenv';
+import readline from 'readline';
+import { createSecureStorage } from '../github/storage';
+import { GitHubOAuth } from '../github/oauth';
+import { createGitHubClient } from '../github/client';
+import type { DeviceFlowStart } from '../github/types';
+import { consoleLogger } from '../github/logger';
+
+dotenv.config();
+
+const storage = createSecureStorage();
+const oauth = new GitHubOAuth({ storage });
+const client = createGitHubClient({ storage });
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+const waitForEnter = (message: string) =>
+  new Promise<void>((resolve) => {
+    rl.question(message, () => resolve());
+  });
+
+const showDeviceInstructions = (device: DeviceFlowStart) => {
+  consoleLogger.info('请在浏览器中访问 GitHub 完成授权', {
+    verificationUri: device.verificationUriComplete || device.verificationUri,
+    userCode: device.userCode,
+  });
+  console.info(`\n请打开浏览器访问: ${device.verificationUri}`);
+  console.info(`输入授权码: ${device.userCode}`);
+  if (device.verificationUriComplete) {
+    console.info(`或直接打开: ${device.verificationUriComplete}`);
+  }
+};
+
+const authStart = async () => {
+  const start = await oauth.startAuthorization({ forceFlow: process.env.FORCE_FLOW as any });
+  if (start.flow === 'auth_code') {
+    console.info('请在浏览器中打开以下链接完成授权:');
+    console.info(start.authorizationUrl);
+    await waitForEnter('\n完成后按回车继续...');
+    const url = new URL(await new Promise<string>((resolve) => rl.question('粘贴完整回调 URL: ', resolve)));
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    if (!code || !state) {
+      throw new Error('回调参数缺失');
+    }
+    const result = await oauth.handleAuthorizationCodeCallback(code, state);
+    console.info(`授权成功，欢迎 ${result.user.login}`);
+  } else {
+    showDeviceInstructions(start);
+    const controller = new AbortController();
+    const onCancel = () => controller.abort();
+    process.on('SIGINT', onCancel);
+    try {
+      const result = await oauth.waitForDeviceToken(start, controller.signal);
+      console.info(`授权成功，欢迎 ${result.user.login}`);
+    } finally {
+      process.off('SIGINT', onCancel);
+    }
+  }
+};
+
+const authWhoAmI = async () => {
+  const account = await storage.getAccount();
+  if (!account) {
+    console.info('尚未登录');
+    return;
+  }
+  const profile = await client.checkToken();
+  console.info(`当前账号: ${profile.user.login} (#${profile.user.id})`);
+  console.info(`Scopes: ${profile.scopes.join(', ')}`);
+};
+
+const runRepoTest = async () => {
+  const owner = process.env.TEST_OWNER;
+  const repo = process.env.TEST_REPO;
+  if (!owner || !repo) {
+    throw new Error('TEST_OWNER/TEST_REPO 未配置');
+  }
+  const who = await client.checkToken();
+  console.info(`使用账号 ${who.user.login} 测试仓库 ${owner}/${repo}`);
+  await client.checkRateLimit();
+  const access = await client.checkRepoAccess(owner, repo);
+  if (!access.hasWrite) {
+    throw new Error('仓库写权限不足');
+  }
+  const timestamp = new Date().toISOString();
+  const issue = await client.createIssue(owner, repo, {
+    title: `healthcheck: ${timestamp}`,
+    body: '自动化测试创建的 Issue',
+  });
+  console.info(`创建 Issue #${issue.number}`);
+  await client.commentIssue(owner, repo, issue.number, '健康检查评论');
+  await client.closeIssue(owner, repo, issue.number);
+  console.info('Issue 创建/评论/关闭流程完成');
+};
+
+const revoke = async () => {
+  await oauth.revokeToken();
+  console.info('已撤销并清除本地凭证');
+};
+
+const main = async () => {
+  const command = process.argv[2];
+  try {
+    switch (command) {
+      case 'auth:start':
+        await authStart();
+        break;
+      case 'auth:whoami':
+        await authWhoAmI();
+        break;
+      case 'test:repo':
+        await runRepoTest();
+        break;
+      case 'auth:revoke':
+        await revoke();
+        break;
+      default:
+        console.info('可用命令: auth:start | auth:whoami | test:repo | auth:revoke');
+    }
+  } catch (error) {
+    console.error('执行失败', error);
+  } finally {
+    rl.close();
+  }
+};
+
+if (require.main === module) {
+  main();
+}
+

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -1,0 +1,203 @@
+import { consoleLogger } from './logger';
+import { TokenRevokedError, InsufficientScopeError, ResourceNotFoundError, ValidationError, GitHubApiError } from './errors';
+import type {
+  CreateIssueInput,
+  FetchLike,
+  GitHubClientHealth,
+  GitHubClientOptions,
+  GitHubPermissions,
+  GitHubUser,
+  ListIssuesQuery,
+  RateLimitInfo,
+  RepoAccessCheck,
+  RetryOptions,
+  StoredAccount,
+} from './types';
+
+const API_BASE = 'https://api.github.com';
+
+const defaultFetch: FetchLike = (...args) => fetch(...args);
+
+const DEFAULT_RETRY: RetryOptions = {
+  retries: 3,
+  factor: 2,
+  minTimeout: 500,
+  maxTimeout: 4000,
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isInsufficientScope = (payload: { message?: string }) =>
+  payload.message?.includes('Resource not accessible by integration') ?? false;
+
+const isValidationError = (status: number) => status === 422;
+
+const isTokenInvalid = (status: number, payload: { message?: string }) =>
+  status === 401 && (payload.message?.includes('Bad credentials') || payload.message?.includes('expired'));
+
+const buildQuery = (query: Record<string, string | number | undefined>) => {
+  const params = new URLSearchParams();
+  Object.entries(query).forEach(([key, value]) => {
+    if (typeof value === 'undefined' || value === null || value === '') {
+      return;
+    }
+    params.set(key, String(value));
+  });
+  const result = params.toString();
+  return result ? `?${result}` : '';
+};
+
+/**
+ * Thin wrapper around the GitHub REST API that automatically attaches the stored token
+ * and converts common error codes into descriptive exceptions.
+ */
+export class GitHubClient implements GitHubClientHealth {
+  private readonly fetchImpl: FetchLike;
+
+  private readonly retry: RetryOptions;
+
+  constructor(private readonly options: GitHubClientOptions) {
+    this.fetchImpl = options.fetchImpl ?? defaultFetch;
+    this.retry = DEFAULT_RETRY;
+  }
+
+  private async getAccount(): Promise<StoredAccount> {
+    const account = await this.options.storage.getAccount();
+    if (!account) {
+      throw new Error('尚未完成 GitHub 授权');
+    }
+    return account;
+  }
+
+  private async request<T>(path: string, init: RequestInit = {}, attempt = 0): Promise<T> {
+    const account = await this.getAccount();
+    const headers: HeadersInit = {
+      Accept: 'application/vnd.github+json',
+      Authorization: `${account.tokenType} ${account.accessToken}`,
+      'User-Agent': 'openroutes-github-oauth',
+      ...init.headers,
+    };
+    const response = await this.fetchImpl(`${API_BASE}${path}`, { ...init, headers });
+    if (response.status >= 500 && attempt < this.retry.retries) {
+      const delay = Math.min(this.retry.maxTimeout, this.retry.minTimeout * Math.pow(this.retry.factor, attempt));
+      consoleLogger.warn('GitHub API 5xx，等待后重试', { path, attempt, delay });
+      await sleep(delay);
+      return this.request(path, init, attempt + 1);
+    }
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    const text = await response.text();
+    const payload = text ? (JSON.parse(text) as any) : {};
+    if (response.ok) {
+      consoleLogger.debug('GitHub API success', {
+        path,
+        remaining: response.headers.get('x-ratelimit-remaining'),
+      });
+      return payload as T;
+    }
+    if (isValidationError(response.status)) {
+      throw new ValidationError(payload.message || '请求参数错误', payload.errors);
+    }
+    if (isInsufficientScope(payload)) {
+      throw new InsufficientScopeError('scope 不足或仓库无权限', response.status);
+    }
+    if (isTokenInvalid(response.status, payload)) {
+      throw new TokenRevokedError();
+    }
+    if (response.status === 404) {
+      throw new ResourceNotFoundError(payload.message || '资源不存在');
+    }
+    throw new GitHubApiError(payload.message || 'GitHub API 调用失败', response.status, payload.documentation_url, payload.errors);
+  }
+
+  /**
+   * List repositories available to the authenticated user.
+   */
+  async listRepos(): Promise<any> {
+    return this.request('/user/repos?per_page=100');
+  }
+
+  /**
+   * List issues inside a repository using GitHub's query parameters.
+   */
+  async listIssues(owner: string, repo: string, query: ListIssuesQuery = {}): Promise<any> {
+    const qs = buildQuery(query as Record<string, string>);
+    return this.request(`/repos/${owner}/${repo}/issues${qs}`);
+  }
+
+  /**
+   * Create a new issue.
+   */
+  async createIssue(owner: string, repo: string, input: CreateIssueInput): Promise<any> {
+    const body = JSON.stringify({ title: input.title, body: input.body, labels: input.labels });
+    return this.request(`/repos/${owner}/${repo}/issues`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+  }
+
+  /**
+   * Add a comment to an existing issue.
+   */
+  async commentIssue(owner: string, repo: string, issueNumber: number, body: string): Promise<any> {
+    return this.request(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+  }
+
+  /**
+   * Close an issue by number.
+   */
+  async closeIssue(owner: string, repo: string, issueNumber: number): Promise<any> {
+    return this.request(`/repos/${owner}/${repo}/issues/${issueNumber}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'closed' }),
+    });
+  }
+
+  /**
+   * Check that the stored token is valid and return the GitHub profile + scopes.
+   */
+  async checkToken(): Promise<{ user: GitHubUser; scopes: string[] }> {
+    const payload = await this.request<GitHubUser>('/user');
+    const account = await this.getAccount();
+    return { user: payload, scopes: account.scopes };
+  }
+
+  /**
+   * Inspect current rate limits.
+   */
+  async checkRateLimit(): Promise<RateLimitInfo> {
+    const payload = await this.request<{ resources: RateLimitInfo }>('/rate_limit');
+    const info = payload.resources;
+    consoleLogger.info('GitHub Rate Limit', info.core);
+    return info;
+  }
+
+  /**
+   * Determine read/write access to a repository based on the permissions object.
+   */
+  async checkRepoAccess(owner: string, repo: string): Promise<RepoAccessCheck> {
+    const repoData = await this.request<{ permissions: GitHubPermissions }>(`/repos/${owner}/${repo}`);
+    return {
+      hasRead: repoData.permissions.pull,
+      hasWrite: repoData.permissions.push || repoData.permissions.maintain || repoData.permissions.admin,
+    };
+  }
+}
+
+/**
+ * Factory helper for consumers that prefer functions over `new`.
+ *
+ * @example
+ * const storage = createSecureStorage();
+ * const client = createGitHubClient({ storage });
+ * const issues = await client.listIssues('owner', 'repo', { state: 'open' });
+ */
+export const createGitHubClient = (options: GitHubClientOptions) => new GitHubClient(options);
+

--- a/src/github/config.ts
+++ b/src/github/config.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import type { OAuthConfig } from './types';
+
+const configSchema = z.object({
+  GITHUB_CLIENT_ID: z.string().min(1),
+  GITHUB_CLIENT_SECRET: z.string().min(1),
+  GITHUB_REDIRECT_URI: z.string().url(),
+  GITHUB_DEFAULT_SCOPES: z.string().optional(),
+  GITHUB_ALLOW_PRIVATE_REPO: z
+    .string()
+    .optional()
+    .transform((value) => value === '1' || value === 'true'),
+});
+
+let cachedConfig: OAuthConfig | null = null;
+
+const DEFAULT_SCOPES = ['read:user', 'user:email', 'public_repo', 'repo:status'];
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): OAuthConfig => {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+  const parsed = configSchema.safeParse(env);
+  if (!parsed.success) {
+    throw new Error(`Missing GitHub OAuth configuration: ${parsed.error.message}`);
+  }
+  const scopeString = parsed.data.GITHUB_DEFAULT_SCOPES;
+  const scopes = scopeString ? scopeString.split(',').map((s) => s.trim()).filter(Boolean) : DEFAULT_SCOPES;
+  cachedConfig = {
+    clientId: parsed.data.GITHUB_CLIENT_ID,
+    clientSecret: parsed.data.GITHUB_CLIENT_SECRET,
+    redirectUri: parsed.data.GITHUB_REDIRECT_URI,
+    defaultScopes: scopes,
+    allowPrivateRepo: parsed.data.GITHUB_ALLOW_PRIVATE_REPO,
+  };
+  return cachedConfig;
+};
+
+export const resetConfigCache = () => {
+  cachedConfig = null;
+};
+
+export { DEFAULT_SCOPES };
+

--- a/src/github/errors.ts
+++ b/src/github/errors.ts
@@ -1,0 +1,40 @@
+export class GitHubApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly documentationUrl?: string,
+    public readonly errors?: unknown
+  ) {
+    super(message);
+    this.name = 'GitHubApiError';
+  }
+}
+
+export class InsufficientScopeError extends GitHubApiError {
+  constructor(message: string, status = 403) {
+    super(message, status);
+    this.name = 'InsufficientScopeError';
+  }
+}
+
+export class TokenRevokedError extends GitHubApiError {
+  constructor(message = '令牌失效或已撤销') {
+    super(message, 401);
+    this.name = 'TokenRevokedError';
+  }
+}
+
+export class ResourceNotFoundError extends GitHubApiError {
+  constructor(message: string) {
+    super(message, 404);
+    this.name = 'ResourceNotFoundError';
+  }
+}
+
+export class ValidationError extends GitHubApiError {
+  constructor(message: string, public readonly fields?: unknown) {
+    super(message, 422);
+    this.name = 'ValidationError';
+  }
+}
+

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -1,0 +1,6 @@
+export * from './oauth';
+export * from './client';
+export * from './errors';
+export * from './storage';
+export * from './types';
+export { consoleLogger } from './logger';

--- a/src/github/logger.ts
+++ b/src/github/logger.ts
@@ -1,0 +1,48 @@
+export interface Logger {
+  debug(message: string, meta?: Record<string, unknown>): void;
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: Record<string, unknown>): void;
+}
+
+const redacted = (value: unknown) => {
+  if (typeof value === 'string') {
+    return value.replace(/[A-Za-z0-9]{6,}/g, '***');
+  }
+  return value;
+};
+
+const sanitize = (meta?: Record<string, unknown>) => {
+  if (!meta) {
+    return undefined;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (key.toLowerCase().includes('token')) {
+      result[key] = '***';
+    } else if (typeof value === 'string') {
+      result[key] = redacted(value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+};
+
+export const consoleLogger: Logger = {
+  debug(message, meta) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug(`[github-oauth] ${message}`, sanitize(meta));
+    }
+  },
+  info(message, meta) {
+    console.info(`[github-oauth] ${message}`, sanitize(meta));
+  },
+  warn(message, meta) {
+    console.warn(`[github-oauth] ${message}`, sanitize(meta));
+  },
+  error(message, meta) {
+    console.error(`[github-oauth] ${message}`, sanitize(meta));
+  },
+};
+

--- a/src/github/oauth.ts
+++ b/src/github/oauth.ts
@@ -1,0 +1,369 @@
+import { randomBytes } from 'crypto';
+import { z } from 'zod';
+import { loadConfig } from './config';
+import { consoleLogger } from './logger';
+import { createSecureStorage } from './storage';
+import { createSessionStore } from './sessionStore';
+import type {
+  AuthFlow,
+  AuthCodeStart,
+  AuthorizationOptions,
+  AuthorizationStart,
+  AuthorizationSuccess,
+  DeviceFlowStart,
+  FetchLike,
+  GitHubUser,
+  OAuthConfig,
+  SecureStorage,
+  SessionStateStore,
+  TokenResponse,
+} from './types';
+
+const AUTHORIZATION_URL = 'https://github.com/login/oauth/authorize';
+const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const DEVICE_CODE_URL = 'https://github.com/login/device/code';
+
+const tokenResponseSchema = z.object({
+  access_token: z.string(),
+  token_type: z.string(),
+  scope: z.string().default(''),
+});
+
+const deviceCodeSchema = z.object({
+  device_code: z.string(),
+  user_code: z.string(),
+  verification_uri: z.string(),
+  verification_uri_complete: z.string().optional(),
+  expires_in: z.number(),
+  interval: z.number().optional().default(5),
+});
+
+const deviceErrorSchema = z.object({
+  error: z.string(),
+  error_description: z.string().optional(),
+});
+
+const hasWindow = () => typeof window !== 'undefined';
+const defaultFetch: FetchLike = (...args) => fetch(...args);
+
+const joinScopes = (scopes: string[]) => Array.from(new Set(scopes.filter(Boolean))).join(' ');
+
+const parseScopes = (scope: string | null | undefined) =>
+  scope ? scope.split(',').map((item) => item.trim()).filter(Boolean) : [];
+
+const browserAvailable = () => hasWindow() && typeof window.location !== 'undefined';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isAbortError = (error: unknown) => error instanceof DOMException && error.name === 'AbortError';
+
+/**
+ * High-level orchestrator for GitHub OAuth flows (authorization code & device flow).
+ * Inject custom storage/session/fetch implementations to adapt for web, mobile or CLI environments.
+ *
+ * @example
+ * const storage = createSecureStorage();
+ * const oauth = new GitHubOAuth({ storage });
+ * const start = await oauth.startAuthorization();
+ */
+export class GitHubOAuth {
+  private readonly config: OAuthConfig;
+
+  private readonly storage: SecureStorage;
+
+  private readonly sessionStore: SessionStateStore;
+
+  private readonly fetchImpl: FetchLike;
+
+  constructor({
+    config = loadConfig(),
+    storage = createSecureStorage(),
+    sessionStore = createSessionStore(),
+    fetchImpl = defaultFetch,
+  }: {
+    config?: OAuthConfig;
+    storage?: SecureStorage;
+    sessionStore?: SessionStateStore;
+    fetchImpl?: FetchLike;
+  } = {}) {
+    this.config = config;
+    this.storage = storage;
+    this.sessionStore = sessionStore;
+    this.fetchImpl = fetchImpl;
+  }
+
+  /**
+   * Start the authorization flow. Automatically selects the best flow unless `forceFlow` is provided.
+   *
+   * @param options Flow hints (scopes override, forceFlow, browser availability).
+   * @returns Authorization payload describing the chosen flow.
+   */
+  async startAuthorization(options: AuthorizationOptions = {}): Promise<AuthorizationStart> {
+    const scopes = this.resolveScopes(options.scopes);
+    const flow = this.pickFlow(options);
+    consoleLogger.info('Starting GitHub authorization', { flow, scopes });
+    if (flow === 'auth_code') {
+      return this.startAuthCodeFlow(scopes, options.state);
+    }
+    return this.startDeviceFlow(scopes);
+  }
+
+  private resolveScopes(scopes?: string[]): string[] {
+    const merged = scopes && scopes.length > 0 ? scopes : this.config.defaultScopes;
+    if (this.config.allowPrivateRepo && !merged.includes('repo')) {
+      return [...new Set([...merged, 'repo'])];
+    }
+    return [...new Set(merged)];
+  }
+
+  private pickFlow(options: AuthorizationOptions): AuthFlow {
+    if (options.forceFlow) {
+      return options.forceFlow;
+    }
+    const hasBrowser = options.browserAvailable ?? browserAvailable();
+    return hasBrowser ? 'auth_code' : 'device';
+  }
+
+  private async startAuthCodeFlow(scopes: string[], providedState?: string): Promise<AuthCodeStart> {
+    const state = providedState ?? randomBytes(16).toString('hex');
+    await this.sessionStore.setState(state, Date.now() + 10 * 60 * 1000);
+    const params = new URLSearchParams({
+      client_id: this.config.clientId,
+      redirect_uri: this.config.redirectUri,
+      scope: joinScopes(scopes),
+      state,
+      allow_signup: 'false',
+    });
+    consoleLogger.info('Generated authorization URL', { scopes });
+    return {
+      flow: 'auth_code',
+      authorizationUrl: `${AUTHORIZATION_URL}?${params.toString()}`,
+      state,
+      scopes,
+    };
+  }
+
+  private async startDeviceFlow(scopes: string[]): Promise<DeviceFlowStart> {
+    const response = await this.fetchImpl(DEVICE_CODE_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: this.config.clientId,
+        scope: joinScopes(scopes),
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to start device authorization: ${response.status}`);
+    }
+    const payload = await response.json();
+    const parsed = deviceCodeSchema.parse(payload);
+    consoleLogger.info('Device authorization initialized', {
+      scopes,
+      interval: parsed.interval,
+      expiresIn: parsed.expires_in,
+    });
+    return {
+      flow: 'device',
+      deviceCode: parsed.device_code,
+      userCode: parsed.user_code,
+      verificationUri: parsed.verification_uri,
+      verificationUriComplete: parsed.verification_uri_complete,
+      expiresIn: parsed.expires_in,
+      interval: parsed.interval,
+      scopes,
+    };
+  }
+
+  /**
+   * Complete the authorization-code flow after GitHub redirects back with `code` and `state`.
+   *
+   * @param code GitHub-provided authorization code.
+   * @param state State returned by GitHub, validated against the locally stored value.
+   * @returns Authorized account, raw token payload and user profile.
+   */
+  async handleAuthorizationCodeCallback(code: string, state: string): Promise<AuthorizationSuccess> {
+    const valid = await this.sessionStore.consumeState(state);
+    if (!valid) {
+      throw new Error('State 校验失败，可能存在 CSRF 风险');
+    }
+    const token = await this.exchangeAuthCode(code);
+    return this.finalizeAuthorization(token);
+  }
+
+  private async exchangeAuthCode(code: string): Promise<TokenResponse> {
+    const response = await this.fetchImpl(ACCESS_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: this.config.clientId,
+        client_secret: this.config.clientSecret,
+        code,
+        redirect_uri: this.config.redirectUri,
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to exchange authorization code: ${response.status}`);
+    }
+    const payload = await response.json();
+    if ('error' in payload) {
+      throw new Error(payload.error_description || '授权失败');
+    }
+    return tokenResponseSchema.parse(payload);
+  }
+
+  /**
+   * Poll the device-flow endpoint until GitHub issues a token.
+   * Handles `authorization_pending`, `slow_down`, `expired_token` and `access_denied` cases.
+   *
+   * @param start Device flow descriptor returned by {@link startAuthorization}.
+   * @param abortSignal Optional signal to cancel polling (e.g. CTRL+C).
+   */
+  async waitForDeviceToken(start: DeviceFlowStart, abortSignal?: AbortSignal): Promise<AuthorizationSuccess> {
+    const startedAt = Date.now();
+    let interval = start.interval * 1000;
+    while (Date.now() - startedAt < start.expiresIn * 1000) {
+      if (abortSignal?.aborted) {
+        throw new Error('授权已取消');
+      }
+      await sleep(interval);
+      try {
+        const token = await this.exchangeDeviceCode(start.deviceCode);
+        return this.finalizeAuthorization(token);
+      } catch (error) {
+        if (isAbortError(error)) {
+          throw error;
+        }
+        if (error instanceof DeviceFlowPendingError) {
+          continue;
+        }
+        if (error instanceof DeviceFlowSlowDownError) {
+          interval = Math.min(interval + 5000, 30000);
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error('设备码已过期，请重新开始授权');
+  }
+
+  private async exchangeDeviceCode(deviceCode: string): Promise<TokenResponse> {
+    const response = await this.fetchImpl(ACCESS_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: this.config.clientId,
+        client_secret: this.config.clientSecret,
+        device_code: deviceCode,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      }),
+    });
+    const payload = await response.json();
+    if (payload.error) {
+      const parsed = deviceErrorSchema.parse(payload);
+      switch (parsed.error) {
+        case 'authorization_pending':
+          throw new DeviceFlowPendingError(parsed.error_description || '等待用户完成授权');
+        case 'slow_down':
+          throw new DeviceFlowSlowDownError(parsed.error_description || '轮询过快，请稍后重试');
+        case 'expired_token':
+          throw new Error('设备码过期，请重新开始授权');
+        case 'access_denied':
+          throw new Error('用户拒绝了授权请求');
+        default:
+          throw new Error(parsed.error_description || parsed.error);
+      }
+    }
+    return tokenResponseSchema.parse(payload);
+  }
+
+  private async finalizeAuthorization(token: TokenResponse): Promise<AuthorizationSuccess> {
+    const scopes = parseScopes(token.scope);
+    const userResponse = await this.fetchImpl('https://api.github.com/user', {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `${token.token_type} ${token.access_token}`,
+      },
+    });
+    if (!userResponse.ok) {
+      throw new Error(`Failed to fetch user profile: ${userResponse.status}`);
+    }
+    const user: GitHubUser = await userResponse.json();
+    const headerScopes = parseScopes(userResponse.headers.get('x-oauth-scopes'));
+    const finalScopes = headerScopes.length > 0 ? headerScopes : scopes;
+    consoleLogger.info('Token issued', { scopes: finalScopes });
+    const account = {
+      userId: user.id,
+      login: user.login,
+      avatarUrl: user.avatar_url,
+      accessToken: token.access_token,
+      scopes: finalScopes,
+      tokenType: token.token_type,
+      createdAt: new Date().toISOString(),
+    };
+    await this.storage.saveAccount(account);
+    return { account, rawToken: token, user };
+  }
+
+  /**
+   * Load the currently stored account information.
+   */
+  async getCurrentAccount() {
+    return this.storage.getAccount();
+  }
+
+  /**
+   * Clear local storage without revoking the remote token.
+   */
+  async signOut() {
+    await this.storage.clear();
+  }
+
+  /**
+   * Revoke the stored token via GitHub API and clear local storage.
+   */
+  async revokeToken(): Promise<void> {
+    const account = await this.storage.getAccount();
+    if (!account) {
+      return;
+    }
+    const response = await this.fetchImpl(`https://api.github.com/applications/${this.config.clientId}/grant`, {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Basic ${Buffer.from(`${this.config.clientId}:${this.config.clientSecret}`).toString('base64')}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ access_token: account.accessToken }),
+    });
+    if (response.status === 404) {
+      consoleLogger.warn('Token already revoked or unknown to application');
+    }
+    await this.storage.clear();
+  }
+}
+
+class DeviceFlowPendingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DeviceFlowPendingError';
+  }
+}
+
+class DeviceFlowSlowDownError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DeviceFlowSlowDownError';
+  }
+}
+
+export { DeviceFlowPendingError, DeviceFlowSlowDownError };
+

--- a/src/github/sessionStore.ts
+++ b/src/github/sessionStore.ts
@@ -1,0 +1,55 @@
+import type { SessionStateStore } from './types';
+
+const STATE_PREFIX = 'github_oauth_state_';
+
+const hasWindow = () => typeof window !== 'undefined' && !!window.sessionStorage;
+
+export class MemorySessionStateStore implements SessionStateStore {
+  private states = new Map<string, number>();
+
+  async setState(state: string, expiresAt: number) {
+    this.states.set(state, expiresAt);
+  }
+
+  async consumeState(state: string): Promise<boolean> {
+    const expiresAt = this.states.get(state);
+    if (!expiresAt) {
+      return false;
+    }
+    if (Date.now() > expiresAt) {
+      this.states.delete(state);
+      return false;
+    }
+    this.states.delete(state);
+    return true;
+  }
+}
+
+export class WebSessionStateStore implements SessionStateStore {
+  async setState(state: string, expiresAt: number): Promise<void> {
+    if (!hasWindow()) {
+      throw new Error('sessionStorage not available');
+    }
+    window.sessionStorage.setItem(`${STATE_PREFIX}${state}`, expiresAt.toString());
+  }
+
+  async consumeState(state: string): Promise<boolean> {
+    if (!hasWindow()) {
+      throw new Error('sessionStorage not available');
+    }
+    const value = window.sessionStorage.getItem(`${STATE_PREFIX}${state}`);
+    if (!value) {
+      return false;
+    }
+    window.sessionStorage.removeItem(`${STATE_PREFIX}${state}`);
+    return Number(value) > Date.now();
+  }
+}
+
+export const createSessionStore = (): SessionStateStore => {
+  if (hasWindow()) {
+    return new WebSessionStateStore();
+  }
+  return new MemorySessionStateStore();
+};
+

--- a/src/github/storage/index.ts
+++ b/src/github/storage/index.ts
@@ -1,0 +1,295 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { createStore, get, set, del } from 'idb-keyval';
+import type { SecureStorage, StoredAccount } from '../types';
+import { consoleLogger } from '../logger';
+
+const SERVICE_ACCOUNT = 'github-account';
+
+const safeParse = (value: string | null) => {
+  if (!value) {
+    return null;
+  }
+  try {
+    return JSON.parse(value) as StoredAccount;
+  } catch (error) {
+    consoleLogger.warn('Failed to parse stored account');
+    return null;
+  }
+};
+
+const ensureDir = async (dir: string) => {
+  await fs.mkdir(dir, { recursive: true });
+};
+
+const KEYTAR_SERVICE = 'openroutes-github-oauth';
+
+let keytarModule: typeof import('keytar') | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  keytarModule = require('keytar');
+} catch (error) {
+  consoleLogger.warn('keytar not available, falling back to encrypted file storage');
+}
+
+let nodeCrypto: typeof import('crypto') | null = null;
+const getNodeCrypto = () => {
+  if (!nodeCrypto) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    nodeCrypto = require('crypto');
+  }
+  return nodeCrypto!;
+};
+
+const dataFile = path.join(os.homedir(), '.config', 'openroutes', 'github-oauth.dat');
+const keyFile = path.join(os.homedir(), '.config', 'openroutes', 'github-oauth.key');
+
+const generateFileKey = async () => {
+  const key = getNodeCrypto().randomBytes(32);
+  await ensureDir(path.dirname(keyFile));
+  await fs.writeFile(keyFile, key.toString('base64'), { mode: 0o600 });
+  return key;
+};
+
+const readFileKey = async (): Promise<Buffer> => {
+  try {
+    const raw = await fs.readFile(keyFile, 'utf8');
+    return Buffer.from(raw, 'base64');
+  } catch (error) {
+    return generateFileKey();
+  }
+};
+
+const encryptFilePayload = async (account: StoredAccount): Promise<Buffer> => {
+  const key = await readFileKey();
+  const iv = getNodeCrypto().randomBytes(12);
+  const cipher = getNodeCrypto().createCipheriv('aes-256-gcm', key, iv);
+  const payload = Buffer.from(JSON.stringify(account), 'utf8');
+  const encrypted = Buffer.concat([cipher.update(payload), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]);
+};
+
+const decryptFilePayload = async (buffer: Buffer): Promise<StoredAccount | null> => {
+  const key = await readFileKey();
+  const iv = buffer.subarray(0, 12);
+  const tag = buffer.subarray(12, 28);
+  const data = buffer.subarray(28);
+  try {
+    const decipher = getNodeCrypto().createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(tag);
+    const decrypted = Buffer.concat([decipher.update(data), decipher.final()]).toString('utf8');
+    return JSON.parse(decrypted) as StoredAccount;
+  } catch (error) {
+    consoleLogger.error('Failed to decrypt secure store payload', { error: (error as Error).message });
+    return null;
+  }
+};
+
+/**
+ * Secure storage for Node.js / desktop environments. Uses OS keychain via `keytar`
+ * when available, otherwise falls back to AES-256-GCM encrypted files under `~/.config/openroutes`.
+ */
+export class NodeSecureStorage implements SecureStorage {
+  constructor(private readonly service = KEYTAR_SERVICE) {}
+
+  async saveAccount(account: StoredAccount): Promise<void> {
+    if (keytarModule) {
+      await keytarModule.setPassword(this.service, SERVICE_ACCOUNT, JSON.stringify(account));
+      return;
+    }
+    const payload = await encryptFilePayload(account);
+    await ensureDir(path.dirname(dataFile));
+    await fs.writeFile(dataFile, payload, { mode: 0o600 });
+  }
+
+  async getAccount(): Promise<StoredAccount | null> {
+    if (keytarModule) {
+      const value = await keytarModule.getPassword(this.service, SERVICE_ACCOUNT);
+      return safeParse(value);
+    }
+    try {
+      const buffer = await fs.readFile(dataFile);
+      return await decryptFilePayload(buffer);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async clear(): Promise<void> {
+    if (keytarModule) {
+      await keytarModule.deletePassword(this.service, SERVICE_ACCOUNT);
+    }
+    try {
+      await fs.unlink(dataFile);
+    } catch (error) {
+      // noop
+    }
+  }
+}
+
+const hasWindow = () => typeof window !== 'undefined' && typeof window.indexedDB !== 'undefined';
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const KEY_STORAGE = 'github_oauth_encryption_key';
+const ACCOUNT_KEY = 'account';
+
+const getWebCrypto = () => {
+  const cryptoApi = (globalThis.crypto ?? getNodeCrypto().webcrypto) as Crypto;
+  if (!cryptoApi?.subtle) {
+    throw new Error('SubtleCrypto not available');
+  }
+  return cryptoApi;
+};
+
+const toBase64 = (bytes: ArrayBuffer | Uint8Array) => {
+  const view = bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : bytes;
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(view).toString('base64');
+  }
+  let binary = '';
+  view.forEach((value) => {
+    binary += String.fromCharCode(value);
+  });
+  return btoa(binary);
+};
+
+const fromBase64 = (value: string): Uint8Array => {
+  if (typeof Buffer !== 'undefined') {
+    const buffer = Buffer.from(value, 'base64');
+    return new Uint8Array(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength));
+  }
+  const binary = atob(value);
+  const out = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    out[index] = binary.charCodeAt(index);
+  }
+  return out;
+};
+
+const randomIv = () => {
+  if (hasWindow()) {
+    const array = new Uint8Array(12);
+    getWebCrypto().getRandomValues(array);
+    return array;
+  }
+  const buffer = getNodeCrypto().randomBytes(12);
+  return new Uint8Array(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength));
+};
+
+const toArrayBuffer = (view: Uint8Array) => {
+  const buffer = new ArrayBuffer(view.byteLength);
+  new Uint8Array(buffer).set(view);
+  return buffer;
+};
+
+const subtleExportKey = async (key: CryptoKey) => {
+  const raw = await getWebCrypto().subtle.exportKey('raw', key);
+  return toBase64(raw);
+};
+
+const subtleImportKey = async (raw: string) => {
+  const bytes = fromBase64(raw);
+  const copy = bytes.slice();
+  const bufferSource = toArrayBuffer(copy) as ArrayBuffer;
+  return getWebCrypto().subtle.importKey('raw', bufferSource, 'AES-GCM', true, ['encrypt', 'decrypt']);
+};
+
+const subtleEncrypt = async (key: CryptoKey, payload: StoredAccount) => {
+  const ivSource = randomIv().slice();
+  const data = encoder.encode(JSON.stringify(payload)).slice();
+  const encrypted = await getWebCrypto().subtle.encrypt({ name: 'AES-GCM', iv: ivSource }, key, data as unknown as BufferSource);
+  return {
+    iv: toBase64(ivSource),
+    data: toBase64(encrypted),
+  };
+};
+
+const subtleDecrypt = async (key: CryptoKey, payload: { iv: string; data: string }) => {
+  const iv = fromBase64(payload.iv).slice();
+  const encrypted = fromBase64(payload.data).slice();
+  const result = await getWebCrypto().subtle.decrypt({ name: 'AES-GCM', iv }, key, encrypted as unknown as BufferSource);
+  return JSON.parse(decoder.decode(result)) as StoredAccount;
+};
+
+/**
+ * Secure storage for web environments using IndexedDB + AES-GCM, with the encryption key
+ * persisted in `sessionStorage` for the active browser session.
+ */
+export class WebSecureStorage implements SecureStorage {
+  private store = createStore('github-oauth', 'accounts');
+
+  private async getCryptoKey(): Promise<CryptoKey> {
+    if (!hasWindow()) {
+      throw new Error('IndexedDB not available');
+    }
+    let keyBase64 = window.sessionStorage.getItem(KEY_STORAGE);
+    const cryptoApi = getWebCrypto();
+    if (!keyBase64) {
+      const key = await cryptoApi.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+      keyBase64 = await subtleExportKey(key);
+      window.sessionStorage.setItem(KEY_STORAGE, keyBase64);
+      return key;
+    }
+    return subtleImportKey(keyBase64);
+  }
+
+  async saveAccount(account: StoredAccount): Promise<void> {
+    const key = await this.getCryptoKey();
+    const payload = await subtleEncrypt(key, account);
+    await set(ACCOUNT_KEY, payload, this.store);
+  }
+
+  async getAccount(): Promise<StoredAccount | null> {
+    try {
+      const key = await this.getCryptoKey();
+      const payload = await get<{ iv: string; data: string } | undefined>(ACCOUNT_KEY, this.store);
+      if (!payload) {
+        return null;
+      }
+      return await subtleDecrypt(key, payload);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async clear(): Promise<void> {
+    await del(ACCOUNT_KEY, this.store);
+  }
+}
+
+/**
+ * Simplified in-memory storage (useful for testing).
+ */
+export class InMemorySecureStorage implements SecureStorage {
+  private account: StoredAccount | null = null;
+
+  async saveAccount(account: StoredAccount): Promise<void> {
+    this.account = account;
+  }
+
+  async getAccount(): Promise<StoredAccount | null> {
+    return this.account;
+  }
+
+  async clear(): Promise<void> {
+    this.account = null;
+  }
+}
+
+/**
+ * Auto-detect the optimal secure storage based on the current runtime.
+ *
+ * @example
+ * const storage = createSecureStorage();
+ * await storage.saveAccount(account);
+ */
+export const createSecureStorage = (): SecureStorage => {
+  if (hasWindow()) {
+    return new WebSecureStorage();
+  }
+  return new NodeSecureStorage();
+};
+

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -1,0 +1,152 @@
+import type { Logger } from './logger';
+
+export type AuthFlow = 'auth_code' | 'device';
+
+export interface OAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  defaultScopes: string[];
+  allowPrivateRepo?: boolean;
+}
+
+export interface AuthorizationOptions {
+  scopes?: string[];
+  forceFlow?: AuthFlow;
+  state?: string;
+  browserAvailable?: boolean;
+}
+
+export interface AuthCodeStart {
+  flow: 'auth_code';
+  authorizationUrl: string;
+  state: string;
+  scopes: string[];
+}
+
+export interface DeviceFlowStart {
+  flow: 'device';
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete?: string;
+  expiresIn: number;
+  interval: number;
+  scopes: string[];
+}
+
+export type AuthorizationStart = AuthCodeStart | DeviceFlowStart;
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  scope: string;
+}
+
+export interface DeviceTokenResponse extends TokenResponse {}
+
+export interface GitHubUser {
+  id: number;
+  login: string;
+  avatar_url: string;
+}
+
+export interface StoredAccount {
+  userId: number;
+  login: string;
+  avatarUrl: string;
+  accessToken: string;
+  scopes: string[];
+  tokenType: string;
+  createdAt: string;
+}
+
+export interface SecureStorage {
+  saveAccount(account: StoredAccount): Promise<void>;
+  getAccount(): Promise<StoredAccount | null>;
+  clear(): Promise<void>;
+}
+
+export interface SessionStateStore {
+  setState(state: string, expiresAt: number): Promise<void>;
+  consumeState(state: string): Promise<boolean>;
+}
+
+export interface FetchLike {
+  (input: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+
+export interface RetryOptions {
+  retries: number;
+  factor: number;
+  minTimeout: number;
+  maxTimeout: number;
+}
+
+export interface GitHubClientOptions {
+  storage: SecureStorage;
+  fetchImpl?: FetchLike;
+  logger?: Logger;
+}
+
+export interface ListIssuesQuery {
+  state?: 'open' | 'closed' | 'all';
+  labels?: string;
+  milestone?: string;
+  assignee?: string;
+  creator?: string;
+  mentioned?: string;
+  sort?: 'created' | 'updated' | 'comments';
+  direction?: 'asc' | 'desc';
+  since?: string;
+}
+
+export interface CreateIssueInput {
+  title: string;
+  body?: string;
+  labels?: string[];
+}
+
+export interface GitHubPermissions {
+  admin: boolean;
+  maintain: boolean;
+  push: boolean;
+  triage: boolean;
+  pull: boolean;
+}
+
+export interface RepoAccessCheck {
+  hasRead: boolean;
+  hasWrite: boolean;
+}
+
+export interface RateLimitInfo {
+  core: { limit: number; remaining: number; reset: number };
+  search: { limit: number; remaining: number; reset: number };
+  graphql?: { limit: number; remaining: number; reset: number };
+}
+
+export interface GitHubHealth {
+  tokenValid: boolean;
+  scopes: string[];
+  rateLimit: RateLimitInfo;
+  repoAccess?: RepoAccessCheck;
+}
+
+export interface GitHubClientHealth {
+  checkToken(): Promise<{ user: GitHubUser; scopes: string[] }>; 
+  checkRateLimit(): Promise<RateLimitInfo>;
+  checkRepoAccess(owner: string, repo: string): Promise<RepoAccessCheck>;
+}
+
+export interface AuthorizationSuccess {
+  account: StoredAccount;
+  rawToken: TokenResponse;
+  user: GitHubUser;
+}
+
+export interface OAuthLoggerContext {
+  flow: AuthFlow;
+  scopes: string[];
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "lib": ["ES2021", "DOM"],
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "types": ["jest", "node"]
+  },
+  "include": ["src", "app", "scripts", "__tests__"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,7 +35,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz"
   integrity sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.0", "@babel/core@^7.12.3", "@babel/core@^7.20.0", "@babel/core@^7.23.9", "@babel/core@^7.25.2", "@babel/core@^7.28.4", "@babel/core@^7.4.0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.8.0":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.0", "@babel/core@^7.12.3", "@babel/core@^7.20.0", "@babel/core@^7.23.9", "@babel/core@^7.25.2", "@babel/core@^7.28.4", "@babel/core@^7.4.0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.8.0", "@babel/core@>=7.0.0-beta.0 <8":
   version "7.28.4"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz"
   integrity sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==
@@ -797,6 +797,13 @@
     deepmerge "^3.2.0"
     hoist-non-react-statics "^3.3.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@egjs/hammerjs@^2.0.17":
   version "2.0.17"
   resolved "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz"
@@ -1246,6 +1253,11 @@
   dependencies:
     "@jest/types" "^29.6.3"
 
+"@jest/diff-sequences@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz"
+  integrity sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==
+
 "@jest/environment@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz"
@@ -1262,6 +1274,13 @@
   integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
   dependencies:
     jest-get-type "^29.6.3"
+
+"@jest/expect-utils@30.1.2":
+  version "30.1.2"
+  resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz"
+  integrity sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==
+  dependencies:
+    "@jest/get-type" "30.1.0"
 
 "@jest/expect@^29.7.0":
   version "29.7.0"
@@ -1283,6 +1302,11 @@
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
+
 "@jest/globals@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz"
@@ -1292,6 +1316,14 @@
     "@jest/expect" "^29.7.0"
     "@jest/types" "^29.6.3"
     jest-mock "^29.7.0"
+
+"@jest/pattern@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz"
+  integrity sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==
+  dependencies:
+    "@types/node" "*"
+    jest-regex-util "30.0.1"
 
 "@jest/reporters@^29.7.0":
   version "29.7.0"
@@ -1330,6 +1362,13 @@
   dependencies:
     "@sinclair/typebox" "^0.27.8"
 
+"@jest/schemas@30.0.5":
+  version "30.0.5"
+  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz"
+  integrity sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
+
 "@jest/source-map@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz"
@@ -1359,7 +1398,7 @@
     jest-haste-map "^29.7.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.7.0":
+"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz"
   integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
@@ -1380,7 +1419,7 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^29.6.3":
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -1391,6 +1430,19 @@
     "@types/node" "*"
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
+
+"@jest/types@30.0.5":
+  version "30.0.5"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz"
+  integrity sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==
+  dependencies:
+    "@jest/pattern" "30.0.1"
+    "@jest/schemas" "30.0.5"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    "@types/istanbul-reports" "^3.0.4"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.33"
+    chalk "^4.1.2"
 
 "@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.2", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -1408,7 +1460,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
@@ -1421,7 +1473,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.5"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
@@ -1433,6 +1485,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@mapbox/togeojson@^0.16.2":
   version "0.16.2"
@@ -1894,6 +1954,11 @@
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@sinclair/typebox@^0.34.0":
+  version "0.34.41"
+  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz"
+  integrity sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==
+
 "@sinonjs/commons@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz"
@@ -1933,6 +1998,26 @@
   version "2.0.0"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@turf/along@^7.2.0":
   version "7.2.0"
@@ -3449,7 +3534,7 @@
   resolved "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.45.tgz"
   integrity sha512-qkcUlZmX6c4J8q45taBKTL3p+LbITgyx7qhlPYOdOHZB7B31K0mXbP5YA7i7SgDeEGuI9MnumiKPEMrxg8j3KQ==
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz"
   integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
@@ -3461,12 +3546,20 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^3.0.0":
+"@types/istanbul-reports@^3.0.0", "@types/istanbul-reports@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz"
   integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@^30.0.0":
+  version "30.0.0"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz"
+  integrity sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==
+  dependencies:
+    expect "^30.0.0"
+    pretty-format "^30.0.0"
 
 "@types/jsdom@^20.0.0":
   version "20.0.1"
@@ -3477,14 +3570,14 @@
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
 
-"@types/node@*":
-  version "20.10.6"
-  resolved "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz"
-  integrity sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==
+"@types/node@*", "@types/node@^24.5.2":
+  version "24.5.2"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz"
+  integrity sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~7.12.0"
 
-"@types/stack-utils@^2.0.0":
+"@types/stack-utils@^2.0.0", "@types/stack-utils@^2.0.3":
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
@@ -3499,10 +3592,10 @@
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
-"@types/yargs@^17.0.8":
-  version "17.0.32"
-  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz"
-  integrity sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==
+"@types/yargs@^17.0.33", "@types/yargs@^17.0.8":
+  version "17.0.33"
+  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz"
+  integrity sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3560,14 +3653,14 @@ acorn-globals@^7.0.0:
     acorn "^8.1.0"
     acorn-walk "^8.0.2"
 
-acorn-walk@^8.0.2:
+acorn-walk@^8.0.2, acorn-walk@^8.1.1:
   version "8.3.4"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz"
   integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.1.0, acorn@^8.11.0, acorn@^8.8.1, acorn@^8.8.2:
+acorn@^8.1.0, acorn@^8.11.0, acorn@^8.4.1, acorn@^8.8.1, acorn@^8.8.2:
   version "8.11.3"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
@@ -3630,6 +3723,11 @@ ansi-styles@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
+ansi-styles@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-styles@^6.1.0:
   version "6.2.3"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
@@ -3647,6 +3745,11 @@ anymatch@^3.0.3:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arg@^5.0.2:
   version "5.0.2"
@@ -3704,7 +3807,7 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-babel-jest@^29.7.0:
+"babel-jest@^29.0.0 || ^30.0.0", babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz"
   integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
@@ -3887,6 +3990,15 @@ bignumber.js@*, bignumber.js@^9.1.0:
   resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 bops@0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz"
@@ -3931,12 +4043,12 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
-    fill-range "^7.0.1"
+    fill-range "^7.1.1"
 
 browserslist@^4.24.0, browserslist@^4.25.0, browserslist@^4.25.3, "browserslist@>= 4.21.0":
   version "4.26.2"
@@ -3948,6 +4060,13 @@ browserslist@^4.24.0, browserslist@^4.25.0, browserslist@^4.25.3, "browserslist@
     electron-to-chromium "^1.5.218"
     node-releases "^2.0.21"
     update-browserslist-db "^1.1.3"
+
+bs-logger@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
 
 bser@2.1.1:
   version "2.1.1"
@@ -3961,7 +4080,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@^5.4.3:
+buffer@^5.4.3, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -4052,6 +4171,11 @@ char-regex@^1.0.2:
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
 chownr@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz"
@@ -4088,6 +4212,11 @@ ci-info@^3.2.0, ci-info@^3.3.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
+
+ci-info@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz"
+  integrity sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==
 
 cjs-module-lexer@^1.0.0:
   version "1.4.3"
@@ -4329,6 +4458,11 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@^3.1.5:
   version "3.1.8"
   resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz"
@@ -4459,6 +4593,13 @@ decode-uri-component@^0.2.2:
   resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 dedent@^1.0.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz"
@@ -4511,7 +4652,7 @@ destroy@1.2.0:
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-detect-libc@^2.0.3:
+detect-libc@^2.0.0, detect-libc@^2.0.3:
   version "2.1.0"
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz"
   integrity sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==
@@ -4530,6 +4671,11 @@ diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4557,7 +4703,17 @@ dotenv-expand@~11.0.6:
   dependencies:
     dotenv "^16.4.5"
 
-dotenv@^16.4.5, dotenv@~16.4.5:
+dotenv@^16.4.5:
+  version "16.6.1"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
+
+dotenv@^17.2.2:
+  version "17.2.2"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz"
+  integrity sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==
+
+dotenv@~16.4.5:
   version "16.4.7"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz"
   integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
@@ -4620,6 +4776,13 @@ encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+  version "1.4.5"
+  resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
+  dependencies:
+    once "^1.4.0"
 
 entities@^6.0.0:
   version "6.0.1"
@@ -4763,6 +4926,11 @@ exit@^0.1.2:
   resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz"
@@ -4773,6 +4941,18 @@ expect@^29.7.0:
     jest-matcher-utils "^29.7.0"
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
+
+expect@^30.0.0:
+  version "30.1.2"
+  resolved "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz"
+  integrity sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==
+  dependencies:
+    "@jest/expect-utils" "30.1.2"
+    "@jest/get-type" "30.1.0"
+    jest-matcher-utils "30.1.2"
+    jest-message-util "30.1.0"
+    jest-mock "30.0.5"
+    jest-util "30.0.5"
 
 expo-asset@~12.0.9:
   version "12.0.9"
@@ -4996,7 +5176,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -5047,10 +5227,10 @@ filenamify@^4.3.0:
     strip-outer "^1.0.1"
     trim-repeated "^1.0.0"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -5143,6 +5323,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-extra@^11.1.1:
   version "11.2.0"
@@ -5254,6 +5439,11 @@ gh-pages@^6.3.0:
     fs-extra "^11.1.1"
     globby "^11.1.0"
 
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
+
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
@@ -5333,10 +5523,22 @@ gopd@^1.2.0:
   resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+handlebars@^4.7.8:
+  version "4.7.8"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -5467,6 +5669,11 @@ iconv-lite@0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+idb-keyval@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz"
+  integrity sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
@@ -5513,7 +5720,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@~2.0.3, inherits@2, inherits@2.0.4:
+inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5770,6 +5977,16 @@ jest-diff@^29.7.0:
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
 
+jest-diff@30.1.2:
+  version "30.1.2"
+  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz"
+  integrity sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==
+  dependencies:
+    "@jest/diff-sequences" "30.0.1"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.0.5"
+
 jest-docblock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz"
@@ -5856,6 +6073,16 @@ jest-matcher-utils@^29.7.0:
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
 
+jest-matcher-utils@30.1.2:
+  version "30.1.2"
+  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz"
+  integrity sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    jest-diff "30.1.2"
+    pretty-format "30.0.5"
+
 jest-message-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz"
@@ -5871,6 +6098,21 @@ jest-message-util@^29.7.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-message-util@30.1.0:
+  version "30.1.0"
+  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.1.0.tgz"
+  integrity sha512-HizKDGG98cYkWmaLUHChq4iN+oCENohQLb7Z5guBPumYs+/etonmNFlg1Ps6yN9LTPyZn+M+b/9BbnHx3WTMDg==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@jest/types" "30.0.5"
+    "@types/stack-utils" "^2.0.3"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    micromatch "^4.0.8"
+    pretty-format "30.0.5"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
+
 jest-mock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz"
@@ -5879,6 +6121,15 @@ jest-mock@^29.7.0:
     "@jest/types" "^29.6.3"
     "@types/node" "*"
     jest-util "^29.7.0"
+
+jest-mock@30.0.5:
+  version "30.0.5"
+  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz"
+  integrity sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==
+  dependencies:
+    "@jest/types" "30.0.5"
+    "@types/node" "*"
+    jest-util "30.0.5"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.3"
@@ -5889,6 +6140,11 @@ jest-regex-util@^29.6.3:
   version "29.6.3"
   resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz"
   integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
+
+jest-regex-util@30.0.1:
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz"
+  integrity sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==
 
 jest-resolve-dependencies@^29.7.0:
   version "29.7.0"
@@ -5994,7 +6250,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-jest-util@^29.7.0:
+"jest-util@^29.0.0 || ^30.0.0", jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
@@ -6005,6 +6261,18 @@ jest-util@^29.7.0:
     ci-info "^3.2.0"
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
+
+jest-util@30.0.5:
+  version "30.0.5"
+  resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz"
+  integrity sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==
+  dependencies:
+    "@jest/types" "30.0.5"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.2"
 
 jest-validate@^29.7.0:
   version "29.7.0"
@@ -6042,7 +6310,7 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.7.0:
+"jest@^29.0.0 || ^30.0.0", jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
@@ -6154,6 +6422,14 @@ jxon@~2.0.0-beta.5:
   integrity sha512-Ot7muZ0v2cmgQ1k+e6bpNcz6E3q2zHssvzYubbKTk5nIEvBLqJfiS6/uivU2ujqKZQlORcjKqcyx6D9X6BEAkQ==
   dependencies:
     xmldom "^0.1.21"
+
+keytar@^7.9.0:
+  version "7.9.0"
+  resolved "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz"
+  integrity sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==
+  dependencies:
+    node-addon-api "^4.3.0"
+    prebuild-install "^7.0.1"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -6270,6 +6546,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz"
@@ -6336,6 +6617,11 @@ make-dir@^4.0.0:
   integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
   dependencies:
     semver "^7.5.3"
+
+make-error@^1.1.1, make-error@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 make-plural@*:
   version "7.3.0"
@@ -6584,12 +6870,12 @@ metro@^0.83.1, metro@0.83.1:
     ws "^7.5.10"
     yargs "^17.6.2"
 
-micromatch@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+micromatch@^4.0.4, micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
-    braces "^3.0.2"
+    braces "^3.0.3"
     picomatch "^2.3.1"
 
 "mime-db@>= 1.43.0 < 2", mime-db@1.52.0:
@@ -6619,6 +6905,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -6640,7 +6931,7 @@ minimatch@^9.0.0, minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.0, minimist@1.2.8:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@1.2.8:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -6656,6 +6947,11 @@ minizlib@^3.1.0:
   integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
   dependencies:
     minipass "^7.1.2"
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp@^1.0.4:
   version "1.0.4"
@@ -6696,6 +6992,11 @@ nanoid@^3.3.11, nanoid@^3.3.7, nanoid@^3.3.8:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
+napi-build-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz"
+  integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
@@ -6706,10 +7007,27 @@ negotiator@0.6.3:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
 nested-error-stacks@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz"
   integrity sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==
+
+node-abi@^3.3.0:
+  version "3.77.0"
+  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz"
+  integrity sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==
+  dependencies:
+    semver "^7.3.5"
+
+node-addon-api@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz"
+  integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
 node-fetch@^2.6.12:
   version "2.7.0"
@@ -6796,7 +7114,7 @@ on-headers@~1.0.2:
   resolved "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -6986,6 +7304,11 @@ picomatch@^3.0.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz"
   integrity sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==
 
+picomatch@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+
 pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.7"
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz"
@@ -7046,6 +7369,24 @@ postcss@~8.4.32:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prebuild-install@^7.0.1:
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz"
+  integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^2.0.0"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 pretty-bytes@^5.6.0:
   version "5.6.0"
   resolved "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz"
@@ -7068,6 +7409,15 @@ pretty-format@^29.7.0:
     "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+pretty-format@^30.0.0, pretty-format@30.0.5:
+  version "30.0.5"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz"
+  integrity sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==
+  dependencies:
+    "@jest/schemas" "30.0.5"
+    ansi-styles "^5.2.0"
+    react-is "^18.3.1"
 
 proc-log@^4.0.0:
   version "4.2.0"
@@ -7107,6 +7457,14 @@ psl@^1.1.33:
   integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
   dependencies:
     punycode "^2.3.1"
+
+pump@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz"
+  integrity sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
@@ -7179,7 +7537,7 @@ rbush@^3.0.1:
   dependencies:
     quickselect "^2.0.0"
 
-rc@~1.2.7:
+rc@^1.2.7, rc@~1.2.7:
   version "1.2.8"
   resolved "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -7228,6 +7586,11 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-is@^19.1.0:
   version "19.1.1"
@@ -7407,7 +7770,7 @@ react@*, "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8 ||
   resolved "https://registry.npmjs.org/react/-/react-19.1.1.tgz"
   integrity sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==
 
-readable-stream@^3.0.2:
+readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -7582,7 +7945,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@~5.1.0, safe-buffer@5.1.2:
+safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -7620,11 +7983,9 @@ semver@^7.1.3:
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 semver@^7.3.5:
-  version "7.6.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz"
-  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
-  dependencies:
-    lru-cache "^6.0.0"
+  version "7.7.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 semver@^7.5.3:
   version "7.7.2"
@@ -7637,6 +7998,11 @@ semver@^7.5.4:
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 semver@^7.6.0:
+  version "7.7.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
@@ -7766,6 +8132,20 @@ signal-exit@^4.0.1:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
 simple-plist@^1.1.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz"
@@ -7858,7 +8238,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-stack-utils@^2.0.3:
+stack-utils@^2.0.3, stack-utils@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz"
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
@@ -8081,6 +8461,27 @@ symbol-tree@^3.2.4:
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tar-fs@^2.0.0:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz"
+  integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 tar@^7.4.3:
   version "7.4.4"
   resolved "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz"
@@ -8228,10 +8629,51 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+ts-jest@^29.4.4:
+  version "29.4.4"
+  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz"
+  integrity sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==
+  dependencies:
+    bs-logger "^0.2.6"
+    fast-json-stable-stringify "^2.1.0"
+    handlebars "^4.7.8"
+    json5 "^2.2.3"
+    lodash.memoize "^4.1.2"
+    make-error "^1.3.6"
+    semver "^7.7.2"
+    type-fest "^4.41.0"
+    yargs-parser "^21.1.1"
+
+ts-node@^10.9.2, ts-node@>=9.0.0:
+  version "10.9.2"
+  resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tslib@^2.0.0, tslib@^2.1.0, tslib@^2.8.1, tslib@2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 type-detect@4.0.8:
   version "4.0.8"
@@ -8248,20 +8690,35 @@ type-fest@^0.7.1:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
+type-fest@^4.41.0:
+  version "4.41.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typescript@^5.9.2, typescript@>=2.7, "typescript@>=4.3 <6":
+  version "5.9.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 ua-parser-js@^1.0.35:
   version "1.0.37"
   resolved "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz"
   integrity sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+uglify-js@^3.1.4:
+  version "3.19.3"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz"
+  integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
+
+undici-types@~7.12.0:
+  version "7.12.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz"
+  integrity sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==
 
 undici@^6.18.2:
   version "6.21.3"
@@ -8373,6 +8830,11 @@ uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"
@@ -8499,6 +8961,11 @@ wonka@^6.3.2:
   version "6.3.5"
   resolved "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz"
   integrity sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 wordwrap@~0.0.2:
   version "0.0.3"
@@ -8650,6 +9117,11 @@ yargs@^17.3.1, yargs@^17.6.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary
- implement a reusable TypeScript GitHub OAuth module that supports authorization code and device flows with secure token storage and logging
- add an authenticated GitHub REST client plus CLI smoke commands for running authorization, whoami, repo workflow, and revoke flows
- configure TypeScript build/test toolchain, provide env template, and document OAuth setup and PAT fallback usage

## Testing
- npm run build
- npm run test:unit
- npm run test:integration

------
https://chatgpt.com/codex/tasks/task_e_68d8d47d58ac8323b9074699101fb843