### PR TITLE
fix: Ensure data source points to yougikou.github.io

### DIFF
--- a/components/apis/GitHubAPI.ts
+++ b/components/apis/GitHubAPI.ts
@@ -92,14 +92,10 @@ export interface RouteFilters {
   [key: string]: string | number | undefined;
 }
 
-const fallbackRepoInfo = (() => {
-  const repoSlug = process.env.GITHUB_REPOSITORY ?? 'yougikou/yougikou.github.io';
-  const parts = repoSlug.split('/');
-  return {
-    owner: parts[0] ?? 'yougikou',
-    repo: parts[1] ?? 'yougikou.github.io',
-  };
-})();
+const fallbackRepoInfo = {
+  owner: 'yougikou',
+  repo: 'yougikou.github.io',
+};
 
 const resolveRepoInfo = () => {
   const owner = process.env.EXPO_PUBLIC_GITHUB_OWNER ?? fallbackRepoInfo.owner;


### PR DESCRIPTION
Updated `components/apis/GitHubAPI.ts` to explicitly set the default repository owner and name to `yougikou` and `yougikou.github.io` respectively. Removed reliance on `process.env.GITHUB_REPOSITORY` for the fallback configuration.

---
*PR created automatically by Jules for task [12405485999418968960](https://jules.google.com/task/12405485999418968960) started by @yougikou*