### PR TITLE
Fix environment variable resolution for data source

### DIFF
--- a/components/apis/GitHubAPI.ts
+++ b/components/apis/GitHubAPI.ts
@@ -98,8 +98,8 @@ const fallbackRepoInfo = {
 };
 
 const resolveRepoInfo = () => {
-  const owner = process.env.EXPO_PUBLIC_GITHUB_OWNER ?? fallbackRepoInfo.owner;
-  const repo = process.env.EXPO_PUBLIC_GITHUB_REPO ?? fallbackRepoInfo.repo;
+  const owner = process.env.EXPO_PUBLIC_GITHUB_OWNER || fallbackRepoInfo.owner;
+  const repo = process.env.EXPO_PUBLIC_GITHUB_REPO || fallbackRepoInfo.repo;
   return { owner, repo };
 };
 


### PR DESCRIPTION
The application was incorrectly resolving the GitHub repository data source to empty strings when `EXPO_PUBLIC_GITHUB_OWNER` or `EXPO_PUBLIC_GITHUB_REPO` were present but empty (e.g., missing secrets in GitHub Actions).

This change updates the resolution logic to use the logical OR operator (`||`) instead of the nullish coalescing operator (`??`). This ensures that falsy values (like empty strings) cause the application to fall back to the default `yougikou/yougikou.github.io` repository, restoring correct functionality in deployment environments.

---
*PR created automatically by Jules for task [7655681596705771462](https://jules.google.com/task/7655681596705771462) started by @yougikou*