### PR TITLE
Add language switching setting (En, Ja, Zh)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,44 +4,55 @@ import { PaperProvider } from 'react-native-paper';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import i18n from '../components/i18n/i18n';
 import { theme } from '../components/theme';
+import { LanguageProvider, useLanguage } from '../components/i18n/LanguageContext';
 
-export default function AppLayout(): React.ReactElement {
+function AppTabs(): React.ReactElement {
+  const { locale } = useLanguage();
+
   return (
-    <PaperProvider theme={theme}>
-      <Tabs screenOptions={{ headerShown: false }}>
-        <Tabs.Screen
-          name="index"
-          options={{
-            tabBarLabel: i18n.t('bottom_explore'),
-            href: '/',
-            tabBarIcon: ({ color, size }) => (
-              <MaterialCommunityIcons name="map-search" color={color} size={size} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="share"
-          options={{
-            tabBarLabel: i18n.t('bottom_share'),
-            href: '/share',
-            tabBarIcon: ({ color, size }) => (
-              <MaterialCommunityIcons name="cloud-upload" color={color} size={size} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="setting"
-          options={{
-            tabBarLabel: i18n.t('bottom_setting'),
-            href: '/setting',
-            tabBarIcon: ({ color, size }) => (
-              <MaterialCommunityIcons name="cog" color={color} size={size} />
-            ),
-          }}
-        />
-        <Tabs.Screen name="githubauth" options={{ href: null }} />
-        <Tabs.Screen name="detail" options={{ href: null }} />
-      </Tabs>
-    </PaperProvider>
+    <Tabs key={locale} screenOptions={{ headerShown: false }}>
+      <Tabs.Screen
+        name="index"
+        options={{
+          tabBarLabel: i18n.t('bottom_explore'),
+          href: '/',
+          tabBarIcon: ({ color, size }) => (
+            <MaterialCommunityIcons name="map-search" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="share"
+        options={{
+          tabBarLabel: i18n.t('bottom_share'),
+          href: '/share',
+          tabBarIcon: ({ color, size }) => (
+            <MaterialCommunityIcons name="cloud-upload" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="setting"
+        options={{
+          tabBarLabel: i18n.t('bottom_setting'),
+          href: '/setting',
+          tabBarIcon: ({ color, size }) => (
+            <MaterialCommunityIcons name="cog" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen name="githubauth" options={{ href: null }} />
+      <Tabs.Screen name="detail" options={{ href: null }} />
+    </Tabs>
+  );
+}
+
+export default function RootLayout(): React.ReactElement {
+  return (
+    <LanguageProvider>
+      <PaperProvider theme={theme}>
+        <AppTabs />
+      </PaperProvider>
+    </LanguageProvider>
   );
 }

--- a/components/i18n/LanguageContext.tsx
+++ b/components/i18n/LanguageContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import i18n from './i18n';
+import { SupportedLocale } from './supportedLanguages';
+
+type LanguageContextType = {
+  locale: SupportedLocale;
+  changeLanguage: (locale: SupportedLocale) => Promise<void>;
+};
+
+const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [locale, setLocale] = useState<SupportedLocale>(i18n.locale as SupportedLocale);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const loadLanguage = async () => {
+      try {
+        const savedLocale = await AsyncStorage.getItem('user-language');
+        if (savedLocale) {
+          i18n.locale = savedLocale;
+          setLocale(savedLocale as SupportedLocale);
+        }
+      } catch (e) {
+        console.error('Failed to load language', e);
+      } finally {
+        setIsLoaded(true);
+      }
+    };
+
+    loadLanguage();
+  }, []);
+
+  const changeLanguage = async (newLocale: SupportedLocale) => {
+    i18n.locale = newLocale;
+    setLocale(newLocale);
+    await AsyncStorage.setItem('user-language', newLocale);
+  };
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  return (
+    <LanguageContext.Provider value={{ locale, changeLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+};

--- a/components/i18n/supportedLanguages.ts
+++ b/components/i18n/supportedLanguages.ts
@@ -39,7 +39,7 @@ export const translations: Record<Locale, TranslationDictionary> = {
     share_submit: 'Submit',
     share_submit_confirmed: 'Route info is submitted. Thank you for sharing. \nYou can view it in exploring screen now. ',
     setting_account: 'Account',
-    setting_github_oauth: 'GithubOAuth Setting',
+    setting_github_oauth: 'Github OAuth Setting',
     github_auth_success: 'Github OAuth Success\nPlease close this window',
     github_auth_failed: 'Github OAuth Failed. Please retry or create issue',
     confirm: 'Okay',
@@ -156,3 +156,9 @@ export const translations: Record<Locale, TranslationDictionary> = {
 };
 
 export type SupportedLocale = keyof typeof translations;
+
+export const SUPPORTED_LANGUAGES: { code: SupportedLocale; label: string }[] = [
+  { code: 'en', label: 'English' },
+  { code: 'zh', label: '中文' },
+  { code: 'ja', label: '日本語' },
+];

--- a/components/screens/SettingScreen.tsx
+++ b/components/screens/SettingScreen.tsx
@@ -6,6 +6,8 @@ import { Appbar, List, useTheme, Surface, Text, Button, Divider, Avatar } from '
 import i18n from '../i18n/i18n';
 import { readData } from '../apis/StorageAPI';
 import Redirector from '../Redirector';
+import { useLanguage } from '../i18n/LanguageContext';
+import { SUPPORTED_LANGUAGES } from '../i18n/supportedLanguages';
 
 const GITHUB_CLIENT_ID = 'cd019fec05aa5b74ad81';
 const redirectUri = AuthSession.makeRedirectUri({
@@ -49,6 +51,7 @@ const SettingScreen = (): React.ReactElement => {
 
   // Adjust container padding based on screen size
   const containerPadding = isDesktop ? 24 : 16;
+  const { locale, changeLanguage } = useLanguage();
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -93,6 +96,28 @@ const SettingScreen = (): React.ReactElement => {
                 titleStyle={{ fontWeight: 'bold' }}
               />
             )}
+          </Surface>
+
+          {/* Language Settings Section */}
+          <View style={[styles.sectionTitleContainer, { marginTop: 24 }]}>
+            <Text variant="titleMedium" style={{ fontWeight: 'bold', color: theme.colors.primary }}>
+              Language / 言語 / 语言
+            </Text>
+          </View>
+          <Surface style={[styles.card, { backgroundColor: theme.colors.surface }]} elevation={1}>
+            <List.Accordion
+              title={SUPPORTED_LANGUAGES.find((l) => l.code === locale)?.label || 'Select Language'}
+              left={(props) => <List.Icon {...props} icon="translate" />}
+            >
+              {SUPPORTED_LANGUAGES.map((lang) => (
+                <List.Item
+                  key={lang.code}
+                  title={lang.label}
+                  right={(props) => (lang.code === locale ? <List.Icon {...props} icon="check" /> : null)}
+                  onPress={() => changeLanguage(lang.code)}
+                />
+              ))}
+            </List.Accordion>
           </Surface>
 
           {/* App Info Section (Example) */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5654,7 +5654,7 @@
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5664,7 +5664,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6805,7 +6805,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {


### PR DESCRIPTION
This PR adds a language switching feature to the application settings. 
It supports English, Japanese, and Chinese. The user's choice is persisted using AsyncStorage.
The implementation uses a Context Provider to manage the global language state and forces a remount of the main navigation stack to ensure all UI elements (including tab labels) are updated immediately.

---
*PR created automatically by Jules for task [15763378111813582317](https://jules.google.com/task/15763378111813582317) started by @yougikou*