### PR TITLE
Fix Share Upload Failures and Improve Error Feedback

### DIFF
--- a/components/apis/GitHubAPI.ts
+++ b/components/apis/GitHubAPI.ts
@@ -383,7 +383,7 @@ const getOrCreateInboxRelease = async (token: string): Promise<GitHubRelease> =>
 const uploadAssetToRelease = async (
   token: string,
   uploadUrlTemplate: string,
-  fileBlob: Blob,
+  fileData: string | Blob,
   fileName: string,
   contentType: string
 ): Promise<string> => {
@@ -397,11 +397,12 @@ const uploadAssetToRelease = async (
       'Content-Type': contentType,
       Accept: 'application/vnd.github.v3+json',
     },
-    body: fileBlob,
+    body: fileData,
   });
 
   if (!response.ok) {
     const errorBody = await response.text();
+    console.error(`Failed to upload asset to ${uploadUrl}: ${response.status} ${errorBody}`);
     throw new Error(`Failed to upload asset: ${response.status} ${errorBody}`);
   }
 
@@ -415,9 +416,9 @@ export const uploadGeoJsonFile = async (
   token: string,
   fileName: string
 ): Promise<string> => {
-  const geoJsonBlob = new Blob([JSON.stringify(geoJsonData)], { type: 'application/json' });
+  const geoJsonString = JSON.stringify(geoJsonData);
   const release = await getOrCreateInboxRelease(token);
-  return uploadAssetToRelease(token, release.upload_url, geoJsonBlob, fileName, 'application/json');
+  return uploadAssetToRelease(token, release.upload_url, geoJsonString, fileName, 'application/json');
 };
 
 export const uploadImgFile = async (base64Data: string): Promise<string> => {

--- a/components/screens/ShareScreen.tsx
+++ b/components/screens/ShareScreen.tsx
@@ -244,6 +244,7 @@ export default function ShareScreen() {
       onToggleSnackBar(i18n.t('share_submit_confirmed'));
     } catch (error) {
       console.error("Error:", error);
+      onToggleSnackBar("Upload failed: " + error.message);
     } finally {
       setIsProcessing(false);
       // reset input


### PR DESCRIPTION
This PR addresses the issue where the GitHub Release asset (GeoJSON file) was not uploading, causing the subsequent issue creation to fail.

The root cause was identified as likely `Blob` handling issues in the React Native environment. The fix involves:
1.  **Refactoring `uploadGeoJsonFile`** in `components/apis/GitHubAPI.ts` to send the JSON string directly in the fetch body, bypassing `Blob` creation.
2.  **Improving Error Handling** in `components/screens/ShareScreen.tsx` to catch errors during submission and display them to the user via the Snackbar, ensuring failures are not silent.
3.  **Enhancing Logging** in `GitHubAPI.ts` to log specific error responses from the GitHub API.

---
*PR created automatically by Jules for task [2020760774516503217](https://jules.google.com/task/2020760774516503217) started by @yougikou*