### PR TITLE
Fix CORS error on Web file upload

### DIFF
--- a/components/apis/GitHubAPI.ts
+++ b/components/apis/GitHubAPI.ts
@@ -1,5 +1,6 @@
 import yaml from 'js-yaml';
 import type { FeatureCollection } from 'geojson';
+import { Platform } from 'react-native';
 import { deleteData, storeData } from './StorageAPI';
 
 interface IssueAttachment {
@@ -390,7 +391,13 @@ const uploadAssetToRelease = async (
   // Remove the templated part {?name,label}
   const uploadUrl = uploadUrlTemplate.replace(/\{.*?\}/, '') + `?name=${encodeURIComponent(fileName)}`;
 
-  const response = await fetch(uploadUrl, {
+  let fetchUrl = uploadUrl;
+
+  if (Platform.OS === 'web') {
+    fetchUrl = 'https://github-auth-worker.yougikou.workers.dev/proxy-upload?url=' + encodeURIComponent(uploadUrl);
+  }
+
+  const response = await fetch(fetchUrl, {
     method: 'POST',
     headers: {
       Authorization: `token ${token}`,


### PR DESCRIPTION
Implemented a proxy solution to bypass CORS restrictions when uploading assets to GitHub Releases from the web client.

1.  **Cloudflare Worker Update (`worker/index.js`)**:
    -   Added a new `/proxy-upload` endpoint.
    -   It proxies `POST` requests to a target URL specified via query parameter.
    -   Includes a security check to ensure the target URL starts with `https://uploads.github.com`.
    -   Forwards necessary headers (`Authorization`, `Content-Type`, `Accept`) and the request body.
    -   Adds appropriate CORS headers to the response.

2.  **Frontend Update (`components/apis/GitHubAPI.ts`)**:
    -   Imported `Platform` from `react-native`.
    -   Modified `uploadAssetToRelease` to detect if running on `web`.
    -   If on web, constructs the proxy URL using the worker's address and the original upload URL.
    -   Uses the proxy URL for the `fetch` request.

This ensures that file uploads work correctly on the web version of the app, eliminating the "Load failed" error.

---
*PR created automatically by Jules for task [14175738600384189832](https://jules.google.com/task/14175738600384189832) started by @yougikou*