### PR TITLE
Fix deploy workflow to support dynamic default branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,7 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add .github/workflows/update-file-to-issue.yml
             git commit -m "Update route processing workflow from app repo"
-            git push origin main
+            BRANCH=$(git rev-parse --abbrev-ref HEAD)
+            git push origin $BRANCH
             echo "Pushed updated workflow to data repo."
           fi


### PR DESCRIPTION
The "Deploy Workflow to Data Repo" step in `.github/workflows/deploy.yml` was hardcoded to push to `main`. This caused failure when the target data repository used `master` as its default branch. 

This change updates the workflow to dynamically detect the current branch name using `git rev-parse --abbrev-ref HEAD` and push to that branch, ensuring compatibility with both `main` and `master` (or other) default branch names.

---
*PR created automatically by Jules for task [8969682657570025620](https://jules.google.com/task/8969682657570025620) started by @yougikou*