### PR TITLE
Docs: Clarify ACCESS_TOKEN scopes for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ CI/CD (GitHub Actions) を利用する場合、リポジトリの Settings > Sec
     - `EXPO_PUBLIC_GITHUB_REPO`: データソースのリポジトリ名
 
 - **オプション (データソースリポジトリがアプリリポジトリと異なる場合)**
-    - `ACCESS_TOKEN`: データソースリポジトリへ書き込み権限（Workflowの同期など）を持つPersonal Access Token (PAT)
+    - `ACCESS_TOKEN`: データソースリポジトリへ書き込み権限を持つPersonal Access Token (PAT)。
+        - **Classic PAT:** `repo` (Full control)
+        - **Fine-grained PAT:** `Contents` (Read and write) および `Workflows` (Read and write)
 
 ### 実行
 ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -63,7 +63,9 @@ If using CI/CD (GitHub Actions), you must set the following secrets in Settings 
     - `EXPO_PUBLIC_GITHUB_REPO`: Repository name for the data source.
 
 - **Optional (If data source repo differs from app repo)**
-    - `ACCESS_TOKEN`: A Personal Access Token (PAT) with write permissions to the data source repository (for syncing workflows).
+    - `ACCESS_TOKEN`: A Personal Access Token (PAT) with write permissions to the data source repository.
+        - **Classic PAT:** `repo` (Full control)
+        - **Fine-grained PAT:** `Contents` (Read and write) and `Workflows` (Read and write)
 
 ### Running
 ```bash

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -50,7 +50,9 @@ EXPO_PUBLIC_GITHUB_REPO=your_repo_name
     - `EXPO_PUBLIC_GITHUB_REPO`: 数据源的仓库名称。
 
 - **可选 (当数据源仓库与应用仓库不同时)**
-    - `ACCESS_TOKEN`: 拥有数据源仓库写入权限的个人访问令牌 (PAT) (用于同步 Workflow)。
+    - `ACCESS_TOKEN`: 拥有数据源仓库写入权限的个人访问令牌 (PAT)。
+        - **Classic PAT:** `repo` (完全控制)
+        - **Fine-grained PAT:** `Contents` (读写) 和 `Workflows` (读写)
 
 #### 运行
 ```bash


### PR DESCRIPTION
Updated README.md, README_EN.md, and README_ZH.md to explicitly state the required permissions for the `ACCESS_TOKEN` secret.
- Added clarification for Classic PAT (`repo` scope).
- Added clarification for Fine-grained PAT (`Contents` and `Workflows` read/write).

---
*PR created automatically by Jules for task [13665627763203579123](https://jules.google.com/task/13665627763203579123) started by @yougikou*