### PR TITLE
fix: Force quoted strings in GitHub Issue YAML to fix image display

### DIFF
--- a/components/apis/GitHubAPI.ts
+++ b/components/apis/GitHubAPI.ts
@@ -279,7 +279,7 @@ export const createIssue = async (routeData: RouteDraft, token: string): Promise
       description: routeData.description ?? '',
       coverimg: coverImageMarkdown,
       geojson: geojsonMarkdown,
-    }, { lineWidth: -1 }),
+    }, { lineWidth: -1, forceQuotes: true }),
     labels: [routeData.type, routeData.difficulty, 'route'],
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "expo-status-bar": "~3.0.9",
         "geojson-to-kml": "^0.0.1",
         "i18n-js": "^4.5.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "expo-status-bar": "~3.0.9",
     "geojson-to-kml": "^0.0.1",
     "i18n-js": "^4.5.1",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",


### PR DESCRIPTION
This PR fixes an issue where the YAML frontmatter generated for GitHub Issues was using block scalars (`>-`) for `geojson` and `coverimg` fields. This caused the cover image to be rendered as a code block (due to indentation) instead of a visible image in the GitHub Issue body.

By enabling `forceQuotes: true` in `js-yaml`, we ensure that all string values are enclosed in single quotes. This results in a cleaner YAML format and ensures that the Markdown image syntax in `coverimg` is parsed correctly by GitHub's renderer when viewing the issue.

Tested with a reproduction script to verify `js-yaml` behavior with `forceQuotes` and `lineWidth: -1`.

---
*PR created automatically by Jules for task [2222814493690508307](https://jules.google.com/task/2222814493690508307) started by @yougikou*