### PR TITLE
Fix white screen on Map back navigation (Web)

### DIFF
--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -135,11 +135,14 @@ const MapScreen: React.FC<MapScreenProps> = ({ url, title, source }) => {
   };
 
   const handleBack = () => {
-    if (router.canGoBack()) {
-      router.back();
-    } else if (Platform.OS === 'web' && source === 'home' && typeof window !== 'undefined') {
+    if (Platform.OS === 'web' && source === 'home' && typeof window !== 'undefined') {
       // Force browser back to preserve scroll position on Home
       window.history.back();
+      return;
+    }
+
+    if (router.canGoBack()) {
+      router.back();
     } else {
       router.replace('/(tabs)/');
     }


### PR DESCRIPTION
Fixes a bug where clicking the back button on the Map screen (Web) resulted in a white screen. The issue was caused by `router.back()` taking precedence over the web-specific `window.history.back()` logic. By checking for the web condition first, we ensure the intended history navigation occurs, which correctly handles the state restoration for the `HomeScreen`.

---
*PR created automatically by Jules for task [18073629502888427805](https://jules.google.com/task/18073629502888427805) started by @yougikou*