### PR TITLE
Fix MapScreen back button navigation on Web

### DIFF
--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -135,12 +135,6 @@ const MapScreen: React.FC<MapScreenProps> = ({ url, title, source }) => {
   };
 
   const handleBack = () => {
-    if (Platform.OS === 'web' && source === 'home' && typeof window !== 'undefined') {
-      // Force browser back to preserve scroll position on Home
-      window.history.back();
-      return;
-    }
-
     if (router.canGoBack()) {
       router.back();
     } else {


### PR DESCRIPTION
This change fixes an issue where the back button on the MapScreen would not function correctly on the Web platform due to reliance on `window.history.back()`. The solution replaces this with `router.back()` from Expo Router, which correctly handles the navigation stack in the SPA context.

---
*PR created automatically by Jules for task [3087638140735781973](https://jules.google.com/task/3087638140735781973) started by @yougikou*