### PR TITLE
Refactor Map "Open in New Window" button and logic

### DIFF
--- a/app/map.tsx
+++ b/app/map.tsx
@@ -3,7 +3,7 @@ import { useLocalSearchParams } from 'expo-router';
 import MapScreen from '../components/screens/MapScreen';
 
 export default function MapRoute() {
-  const { url, title, source } = useLocalSearchParams<{ url: string; title: string; source: string }>();
+  const { url, title, source, standalone } = useLocalSearchParams<{ url: string; title: string; source: string; standalone?: string }>();
 
-  return <MapScreen url={url} title={title} source={source} />;
+  return <MapScreen url={url} title={title} source={source} standalone={standalone} />;
 }

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -184,9 +184,10 @@ interface MapScreenProps {
   url?: string;
   title?: string;
   source?: string;
+  standalone?: string;
 }
 
-const MapScreen: React.FC<MapScreenProps> = ({ url, title, source }) => {
+const MapScreen: React.FC<MapScreenProps> = ({ url, title, source, standalone }) => {
   const theme = useTheme();
   const router = useRouter();
   const [geoJsonData, setGeoJsonData] = useState<any>(null);
@@ -310,7 +311,9 @@ const MapScreen: React.FC<MapScreenProps> = ({ url, title, source }) => {
 
   const handleOpenInBrowser = () => {
     if (Platform.OS === 'web') {
-        window.open(window.location.href, '_blank');
+        const currentUrl = new URL(window.location.href);
+        currentUrl.searchParams.set('standalone', 'true');
+        window.open(currentUrl.toString(), '_blank');
     } else {
         if (url) Linking.openURL(convertBlobUrlToRawUrl(url));
     }
@@ -462,13 +465,14 @@ const MapScreen: React.FC<MapScreenProps> = ({ url, title, source }) => {
          size="small"
        />
 
-       <FAB
-         icon="open-in-new"
-         style={[styles.openFab, { backgroundColor: theme.colors.surface }]}
-         onPress={handleOpenInBrowser}
-         size="small"
-         label="Open in New Window"
-       />
+       {!standalone && (
+         <FAB
+           icon="open-in-new"
+           style={[styles.openFab, { backgroundColor: theme.colors.surface }]}
+           onPress={handleOpenInBrowser}
+           size="small"
+         />
+       )}
 
        <View style={[styles.titleContainer, { backgroundColor: theme.colors.surfaceVariant }]}>
           <Text variant="titleMedium" numberOfLines={1}>{title || 'Route Map'}</Text>
@@ -507,7 +511,7 @@ const styles = StyleSheet.create({
   openFab: {
     position: 'absolute',
     bottom: 32,
-    right: 16,
+    left: 16,
     zIndex: 10000,
   },
   titleContainer: {

--- a/expo_output.log
+++ b/expo_output.log
@@ -1,0 +1,67 @@
+
+> openroutes@1.0.0 web
+> expo start --web --port 8081
+
+env: load .env
+env: export EXPO_PUBLIC_GITHUB_OWNER EXPO_PUBLIC_GITHUB_REPO GITHUB_REPOSITORY
+[33m[1mWarning: [22mRoot-level [1m"expo"[22m object found. Ignoring extra keys in Expo config: "scheme", "platforms"
+[90mLearn more: https://expo.fyi/root-expo-object[0m[0m
+Starting project at /app
+Starting Metro Bundler
+Waiting on http://localhost:8081
+Logs for your project will appear below.
+Web node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
+Web node_modules/expo-router/entry.js ▓▓▓░░░░░░░░░░░░░ 19.8% ( 77/178)
+λ node_modules/expo-router/node/render.js ▓▓░░░░░░░░░░░░░░ 17.6% (129/312)
+| [33m[1mWarning: [22mRoot-level [1m"expo"[22m object found. Ignoring extra keys in Expo config: "scheme", "platforms"
+| [90mLearn more: https://expo.fyi/root-expo-object[0m[0m
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓░░░░░░░░ 50.2% (233/370)
+λ node_modules/expo-router/node/render.js ▓▓▓▓▓▓▓▓▓▓░░░░░░ 63.4% (473/594)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓░░░░░░░░ 54.8% (387/523)
+λ node_modules/expo-router/node/render.js ▓▓▓▓▓▓▓▓▓▓░░░░░░ 64.3% (587/805)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓░░░░░░ 62.5% (508/653)
+λ node_modules/expo-router/node/render.js ▓▓▓▓▓▓▓▓▓▓░░░░░░ 64.3% ( 858/1155)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓░░░░░░ 62.5% (636/850)
+λ node_modules/expo-router/node/render.js ▓▓▓▓▓▓▓▓▓▓▓░░░░░ 73.7% (1129/1328)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓░░░░░░ 62.5% (734/952)
+λ node_modules/expo-router/node/render.js ▓▓▓▓▓▓▓▓▓▓▓▓▓░░░ 85.6% (1300/1405)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓░░░░░ 74.8% (1056/1300)
+λ node_modules/expo-router/node/render.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░ 87.9% (1497/1597)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓▓░░░░ 79.3% (1354/1533)
+λ node_modules/expo-router/node/render.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░ 91.8% (1609/1679)
+λ Bundled 31470ms node_modules/expo-router/node/render.js (1781 modules)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 94.7% (1814/1864)
+"shadow*" style props are deprecated. Use "boxShadow".
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 95.4% (1825/1868)
+Web Bundled 37697ms node_modules/expo-router/entry.js (1959 modules)
+Error: Premature close
+    at onclose (node:internal/streams/end-of-stream:171:30)
+    at processTicksAndRejections (node:internal/process/task_queues:85:11)
+Web node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
+λ Bundled 63ms node_modules/expo-router/node/render.js (1 module)
+"shadow*" style props are deprecated. Use "boxShadow".
+Web Bundled 1204ms node_modules/expo-router/entry.js (1 module)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓░░░░░░░░░░░ 37.1% (268/440)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓░░░░░░░░ 52.0% (657/917)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓░░░░░ 71.9% (1165/1391)
+Web node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░ 92.2% (1775/1849)
+Web Bundled 13439ms node_modules/expo-router/entry.js (1960 modules)
+ LOG  [web] Logs will appear in the browser console
+Web node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
+λ Bundled 64ms node_modules/expo-router/node/render.js (1 module)
+"shadow*" style props are deprecated. Use "boxShadow".
+Web Bundled 573ms node_modules/expo-router/entry.js (1 module)
+Web Bundled 82ms node_modules/expo-router/entry.js (1 module)
+ LOG  [web] Logs will appear in the browser console
+Web node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
+λ Bundled 52ms node_modules/expo-router/node/render.js (1 module)
+"shadow*" style props are deprecated. Use "boxShadow".
+Web Bundled 599ms node_modules/expo-router/entry.js (1 module)
+Web Bundled 84ms node_modules/expo-router/entry.js (1 module)
+ LOG  [web] Logs will appear in the browser console
+Web node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
+λ Bundled 52ms node_modules/expo-router/node/render.js (1 module)
+"shadow*" style props are deprecated. Use "boxShadow".
+Web Bundled 587ms node_modules/expo-router/entry.js (1 module)
+Web Bundled 94ms node_modules/expo-router/entry.js (1 module)
+ LOG  [web] Logs will appear in the browser console


### PR DESCRIPTION
This PR improves the "Open in New Window" functionality in the Map view, specifically targeting PWA usage.
- The button is moved to the bottom-left and is now icon-only for a cleaner UI.
- When clicked, it opens a new window with a `standalone=true` query parameter.
- The new window (standalone mode) hides the "Open in New Window" button to prevent redundancy.
- Verified via Playwright tests.

---
*PR created automatically by Jules for task [17247361772770309074](https://jules.google.com/task/17247361772770309074) started by @yougikou*