### PR TITLE
Fix map preview navigation for pending GeoJSON files

### DIFF
--- a/components/screens/HomeScreen.tsx
+++ b/components/screens/HomeScreen.tsx
@@ -255,14 +255,15 @@ const HomeScreen = (): React.ReactElement => {
                     icon="map-search-outline"
                     size={20}
                     iconColor={theme.colors.primary}
-                    disabled={!geoJsonUri}
                     onPress={() => {
-                      if (geoJsonUri) {
-                        router.push({
-                          pathname: '/map',
-                          params: { url: geoJsonUri, title: item.title, source: 'home' }
-                        });
+                      if (!geoJsonUri || geoJsonUri.indexOf('github') === -1) {
+                        showSnackbar(i18n.t('home_download_prep'));
+                        return;
                       }
+                      router.push({
+                        pathname: '/map',
+                        params: { url: geoJsonUri, title: item.title, source: 'home' }
+                      });
                     }}
                   />
                   <IconButton icon="arrow-right" size={20} iconColor={theme.colors.primary} style={{ marginLeft: 'auto', margin: 0 }} onPress={() => handleToDetail(item)} />


### PR DESCRIPTION
This change ensures that clicking the map icon for a route with a pending or missing GeoJSON file does not navigate to a blank map screen. Instead, it provides feedback to the user that the map preview is being prepared, matching the behavior of the GPX/KML download buttons.

---
*PR created automatically by Jules for task [11379514486797395215](https://jules.google.com/task/11379514486797395215) started by @yougikou*