### PR TITLE
Hide closed issues from route list and search

### DIFF
--- a/components/apis/GitHubAPI.ts
+++ b/components/apis/GitHubAPI.ts
@@ -188,7 +188,18 @@ export const fetchIssues = async (
   });
 
   if (searchQuery && searchQuery.trim().length > 0) {
-    const q = `repo:${owner}/${repo} is:issue label:route ${searchQuery}`;
+    let q = `repo:${owner}/${repo} is:issue label:route ${searchQuery}`;
+    const stateFilter = filters.state;
+    if (stateFilter === 'open') {
+      q += ' is:open';
+    } else if (stateFilter === 'closed') {
+      q += ' is:closed';
+    } else if (stateFilter === 'all') {
+      // do nothing
+    } else {
+      // undefined or unknown -> default to open
+      q += ' is:open';
+    }
     searchParams.append('q', q);
     url = 'https://api.github.com/search/issues?' + searchParams.toString();
   } else {

--- a/components/screens/HomeScreen.tsx
+++ b/components/screens/HomeScreen.tsx
@@ -14,7 +14,7 @@ import { useRouter, useFocusEffect } from 'expo-router';
 import { downloadFile } from '../../utils/FileHelper';
 import { convertBlobUrlToRawUrl } from '../../utils/url';
 
-const FILTERS: RouteFilters = { state: 'all' };
+const FILTERS: RouteFilters = { state: 'open' };
 const PER_PAGE = 10;
 
 interface SnackbarState {


### PR DESCRIPTION
Adjusted the browse screen display data to not show closed issues (route information). Modified the `fetchIssues` function in `GitHubAPI.ts` to respect the state filter during search operations, and updated `HomeScreen.tsx` to request only open issues by default.

---
*PR created automatically by Jules for task [14487197846845185423](https://jules.google.com/task/14487197846845185423) started by @yougikou*