### PR TITLE
Improve Detail Screen UI and Localization

### DIFF
--- a/components/i18n/supportedLanguages.ts
+++ b/components/i18n/supportedLanguages.ts
@@ -78,6 +78,8 @@ export const translations: Record<Locale, TranslationDictionary> = {
     setting_version: 'Version',
     setting_opensource: 'Open Source',
     setting_visit_repo: 'Visit our repository',
+    view_in_map: 'View on Map',
+    detail_info_title: 'Detailed Info',
   },
   zh: {
     bottom_explore: '浏览',
@@ -154,6 +156,8 @@ export const translations: Record<Locale, TranslationDictionary> = {
     setting_version: '版本',
     setting_opensource: '开源',
     setting_visit_repo: '访问我们的仓库',
+    view_in_map: '在地图中查看',
+    detail_info_title: '详细补充信息',
   },
   ja: {
     bottom_explore: '探す',
@@ -230,6 +234,8 @@ export const translations: Record<Locale, TranslationDictionary> = {
     setting_version: 'バージョン',
     setting_opensource: 'オープンソース',
     setting_visit_repo: 'リポジトリを見る',
+    view_in_map: '地図で見る',
+    detail_info_title: '詳細情報',
   },
 };
 

--- a/components/screens/RouteDetailScreen.tsx
+++ b/components/screens/RouteDetailScreen.tsx
@@ -56,7 +56,7 @@ export default function RouteDetailScreen() {
             <Text variant="headlineMedium" style={{ fontWeight: 'bold', marginBottom: 8 }}>{routeItem.title}</Text>
 
             <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 16 }}>
-                <Avatar.Image size={40} source={{ uri: routeItem.user.avatar_url }} />
+                <Avatar.Image size={40} source={{ uri: routeItem.user.avatar_url }} style={{ backgroundColor: 'transparent' }} />
                 <View style={{ marginLeft: 12 }}>
                     <Text variant="titleSmall">{routeItem.user.login}</Text>
                     <Text variant="bodySmall" style={{ color: theme.colors.outline }}>{new Date(routeItem.created_at).toLocaleDateString()}</Text>
@@ -85,8 +85,6 @@ export default function RouteDetailScreen() {
 
             <Divider style={{ marginVertical: 16 }} />
 
-            <Text variant="bodyLarge">{routeItem.description}</Text>
-
             {routeItem.geojson?.uri && (
                  <Button
                     mode="contained"
@@ -99,8 +97,15 @@ export default function RouteDetailScreen() {
                         });
                     }}
                  >
-                    View on Map
+                    {i18n.t('view_in_map')}
                  </Button>
+            )}
+
+            {routeItem.description && (
+                <View style={{ marginTop: 24 }}>
+                   <Text variant="titleMedium" style={{ fontWeight: 'bold', marginBottom: 8 }}>{i18n.t('detail_info_title')}</Text>
+                   <Text variant="bodyLarge">{routeItem.description}</Text>
+                </View>
             )}
          </View>
       </ScrollView>


### PR DESCRIPTION
This PR improves the RouteDetailScreen by polishing the UI and adding missing localizations.
1. The user avatar no longer displays a default green background.
2. The 'View on Map' button is now localized for English, Chinese, and Japanese.
3. The route description (detailed info) has been moved below the map button, as requested, and now includes a localized header to clearly separate it.

---
*PR created automatically by Jules for task [7685614020761840778](https://jules.google.com/task/7685614020761840778) started by @yougikou*