### PR TITLE
Update README.md with vivid description and roadmap (Chinese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,121 @@
-# openroutes
-ハイキング、自転車、散歩などのウェルネスにおすすめのルートは、誰でも無料で利用できるべきです。
+# OpenRoutes - 你的去中心化户外日志 🌲🚵‍♂️
 
-[![日本語](https://img.shields.io/badge/lang-日本語-green.svg)](./README.md)
+探索自然、记录足迹，完全免费且掌控在你手中。
+
+[![日本語](https://img.shields.io/badge/lang-日本語-green.svg)](./README_JP.md)
 [![English](https://img.shields.io/badge/lang-English-blue.svg)](./README_EN.md)
-[![中文](https://img.shields.io/badge/lang-中文-red.svg)](./README_ZH.md)
+[![中文](https://img.shields.io/badge/lang-中文-red.svg)](./README.md)
 
-[デモサイト](https://yougikou.github.io/openroutes/)
+[🌐 访问演示网站](https://yougikou.github.io/openroutes/)
 
-## プロジェクト概要
-OpenRoutesは、React Native (Expo) で構築された、サーバーレスのルート共有プラットフォームです。
-バックエンドとして **GitHub Issues** をデータベースとして利用し、完全無料で運用可能なエコシステムを目指しています。
+## 🌟 什么是 OpenRoutes？
 
-### アーキテクチャ
--   **フロントエンド:** React Native / Expo (Web, iOS, Android対応)
--   **データベース:** GitHub Issues (メタデータ, 説明, コメント)
--   **認証:** GitHub OAuth
--   **ストレージ (現状):**
-    -   画像: Imgur API
-    -   GeoJSON (ルートデータ): GitHub Releases (Inbox) -> GitHub Repo (Assets Branch)
+OpenRoutes 是一个**无服务器 (Serverless)** 的户外路线分享平台，基于 React Native (Expo) 构建。
 
-## 機能
-1.  **ルート一覧 (Explore)**
-    -   GitHub Issuesからルート情報を取得し、リスト表示します。
-    -   GPX / KML 形式でのダウンロードが可能です。
-    -   キーワード検索機能。
-2.  **ルート共有 (Share)**
-    -   GPX / KML ファイルをアップロードし、距離・所要時間・日付を自動解析します。
-    -   写真を添付し、ルートの説明を追加して投稿できます。
-    -   ※ 投稿にはGitHub認証が必要です。
-3.  **認証 (Auth)**
-    -   GitHubアカウントを使用してログインします。
-    -   ログインすることでルート作成が可能になり、APIレート制限が緩和されます。
+与其他平台不同，**我们将 GitHub 作为数据库**。这意味着：
+- **完全免费**：没有订阅费，没有广告。
+- **数据自主**：你的路线数据存储在公开的 GitHub 仓库中，而不是封闭的私有服务器。
+- **社区驱动**：每一个 Issue 就是一条路线，每一次 Comment 就是一次互动。
 
-## 開発環境のセットアップ
+## 📖 用户指南：如何使用
+
+只需简单三步，开启你的去中心化户外之旅。
+
+### 1. 连接你的 GitHub 账号 🔗
+点击右上角的 **GitHub 图标** 进行登录。
+- **为什么需要登录？** 为了防止滥用并突破 API 限制，我们需要验证你的身份。
+- **权限说明**：我们需要读取和写入 Issue 的权限，以便你能发布路线和评论。
+
+### 2. 探索路线 (Explore) 🗺️
+在首页浏览社区分享的徒步、骑行路线。
+- **地图模式**：点击列表中的路线，进入详细地图页面。
+- **下载数据**：支持导出 **GPX** 或 **KML** 文件，导入到你的手表或 GPS 设备中。
+
+### 3. 分享你的足迹 (Share) 📝
+点击底部的 **Share** 标签，上传你的记录。
+- **上传文件**：选择你的 `.gpx` 或 `.kml` 文件。
+- **自动解析**：系统会自动计算距离、爬升和耗时。
+- **添加照片**：上传沿途的美景（目前支持 Imgur 图床）。
+- **发布**：点击提交，你的路线将自动生成为一个 GitHub Issue！
+
+---
+
+## 🔒 数据是如何保存的？
+
+OpenRoutes 采用独特的**Git-as-Backend**架构：
+
+1.  **路线元数据 (Metadata)**：标题、描述、难度等信息存储在 **GitHub Issue** 的正文中 (YAML 格式)。
+2.  **路线文件 (GeoJSON)**：转换后的路线数据存储在 **GitHub Releases** 中 (Tag: `inbox`)，确保持久化存储。
+3.  **图片 (Images)**：目前托管于 **Imgur API** (未来计划迁移至 GitHub 存储)。
+
+---
+
+## 🛠️ 部署与开发指南
+
+如果你是开发者，或者想部署自己的 OpenRoutes 实例，请参考以下步骤。
 
 ### 前提条件
--   Node.js (v22以上推奨)
+-   Node.js (推荐 v22+)
 -   npm
 
-### インストール
+### 安装
 ```bash
 npm install
 ```
 
-### 環境変数設定
+### 环境配置
 
-#### ローカル開発 (`.env`)
-プロジェクトルートに `.env` ファイルを作成し、以下の変数を設定してください。
+#### 本地开发 (`.env`)
+在项目根目录创建 `.env` 文件，配置数据源仓库：
 
 ```ini
-# データソースとなるGitHubリポジトリの所有者
+# 数据源 GitHub 仓库的所有者用户名 (例如: yougikou)
 EXPO_PUBLIC_GITHUB_OWNER=your_github_username
-# データソースとなるGitHubリポジトリ名
+# 数据源 GitHub 仓库名称 (例如: openroutes-data)
 EXPO_PUBLIC_GITHUB_REPO=your_repo_name
 ```
 
-#### GitHub Actions Secrets
-CI/CD (GitHub Actions) を利用する場合、リポジトリの Settings > Secrets and variables > Actions に以下のシークレットを設定する必要があります。
+#### GitHub Actions Secrets (用于 CI/CD)
+若使用 GitHub Actions 自动构建，需在仓库设置中添加 Secrets：
 
-- **必須**
-    - `EXPO_PUBLIC_GITHUB_OWNER`: データソースのGitHubユーザー名
-    - `EXPO_PUBLIC_GITHUB_REPO`: データソースのリポジトリ名
+- `EXPO_PUBLIC_GITHUB_OWNER`: 数据源用户名
+- `EXPO_PUBLIC_GITHUB_REPO`: 数据源仓库名
+- `ACCESS_TOKEN`: (可选) 若数据源在私有仓库或跨仓库操作，需提供具有读写权限的 PAT。
 
-- **オプション (データソースリポジトリがアプリリポジトリと異なる場合)**
-    - `ACCESS_TOKEN`: データソースリポジトリへ書き込み権限を持つPersonal Access Token (PAT)。
-        - **Classic PAT:** `repo` (Full control)
-        - **Fine-grained PAT:** `Contents` (Read and write) および `Workflows` (Read and write)
-
-### 実行
+### 运行项目
 ```bash
-# Webで起動
+# 启动 Web 版
 npm run web
 
-# iOS / Android (Expo Goが必要)
+# 启动 iOS / Android (需要安装 Expo Go)
 npm run ios
 npm run android
 ```
 
-## 現状の課題とロードマップ
--   **データ永続性:** 現在GeoJSONは一時的なストレージ(File.io)に保存されているため、リンク切れのリスクがあります。GitHubリポジトリへの直接コミット等への移行を検討中です。
--   **詳細画面:** ルートの詳細地図表示機能が未実装です。
--   **検索機能:** フィルタリング機能のUI実装が必要です。
+---
+
+## 🚀 蓝图规划 (Roadmap)
+
+我们致力于打造最纯粹的户外社区。以下是我们的开发蓝图：
+
+### ✅ 第一阶段：核心功能 (已完成)
+- [x] **GitHub 登录与认证**：安全的 OAuth 流程。
+- [x] **GPX/KML 解析**：前端自动计算距离与时间。
+- [x] **地图可视化**：基于 Leaflet 的交互式地图。
+- [x] **Issue CMS**：利用 GitHub Issue 管理内容。
+- [x] **PWA 支持**：可安装到手机桌面，离线访问基础功能。
+
+### 🚧 第二阶段：体验升级 (进行中)
+- [ ] **图片存储迁移**：移除 Imgur 依赖，将图片直接存储到 GitHub Issue 附件或 Releases 中，实现 100% 数据去中心化。
+- [ ] **离线地图优化**：改进 PWA 缓存策略，支持离线查看已加载的地图区域。
+- [ ] **深色模式**：适配夜间使用的 UI 主题。
+
+### 🔮 第三阶段：生态扩展 (未来)
+- [ ] **多仓库支持**：允许用户在设置中切换数据源（例如："查看我的私人仓库" vs "查看社区精选"）。
+- [ ] **社交互动**：在 App 内直接渲染 Issue 评论，支持点赞和讨论。
+- [ ] **活动组织**：基于 Issue 的活动报名功能。
 
 ---
-### 開発目的
-自然と接することが好きで、このようなポジティブ、健康的な趣味のため、いろんな安全かつ質が高いルート情報が必要です。いろんなサービスを見てきたが、有料であることがなかなか気が済まなくて．．．
-情報がハイキングユーザから集めるなら、すべてタダにするべき。
+
+### ❤️ 开发初衷
+大自然属于每一个人。我们相信，高质量的户外路线信息不应被付费墙阻隔。OpenRoutes 是为了所有热爱徒步、骑行和探索的朋友们打造的——让信息自由流动，让足迹遍布山川。

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,0 +1,88 @@
+# openroutes
+ハイキング、自転車、散歩などのウェルネスにおすすめのルートは、誰でも無料で利用できるべきです。
+
+[![日本語](https://img.shields.io/badge/lang-日本語-green.svg)](./README_JP.md)
+[![English](https://img.shields.io/badge/lang-English-blue.svg)](./README_EN.md)
+[![中文](https://img.shields.io/badge/lang-中文-red.svg)](./README.md)
+
+[デモサイト](https://yougikou.github.io/openroutes/)
+
+## プロジェクト概要
+OpenRoutesは、React Native (Expo) で構築された、サーバーレスのルート共有プラットフォームです。
+バックエンドとして **GitHub Issues** をデータベースとして利用し、完全無料で運用可能なエコシステムを目指しています。
+
+### アーキテクチャ
+-   **フロントエンド:** React Native / Expo (Web, iOS, Android対応)
+-   **データベース:** GitHub Issues (メタデータ, 説明, コメント)
+-   **認証:** GitHub OAuth
+-   **ストレージ (現状):**
+    -   画像: Imgur API
+    -   GeoJSON (ルートデータ): GitHub Releases (Inbox) -> GitHub Repo (Assets Branch)
+
+## 機能
+1.  **ルート一覧 (Explore)**
+    -   GitHub Issuesからルート情報を取得し、リスト表示します。
+    -   GPX / KML 形式でのダウンロードが可能です。
+    -   キーワード検索機能。
+2.  **ルート共有 (Share)**
+    -   GPX / KML ファイルをアップロードし、距離・所要時間・日付を自動解析します。
+    -   写真を添付し、ルートの説明を追加して投稿できます。
+    -   ※ 投稿にはGitHub認証が必要です。
+3.  **認証 (Auth)**
+    -   GitHubアカウントを使用してログインします。
+    -   ログインすることでルート作成が可能になり、APIレート制限が緩和されます。
+
+## 開発環境のセットアップ
+
+### 前提条件
+-   Node.js (v22以上推奨)
+-   npm
+
+### インストール
+```bash
+npm install
+```
+
+### 環境変数設定
+
+#### ローカル開発 (`.env`)
+プロジェクトルートに `.env` ファイルを作成し、以下の変数を設定してください。
+
+```ini
+# データソースとなるGitHubリポジトリの所有者
+EXPO_PUBLIC_GITHUB_OWNER=your_github_username
+# データソースとなるGitHubリポジトリ名
+EXPO_PUBLIC_GITHUB_REPO=your_repo_name
+```
+
+#### GitHub Actions Secrets
+CI/CD (GitHub Actions) を利用する場合、リポジトリの Settings > Secrets and variables > Actions に以下のシークレットを設定する必要があります。
+
+- **必須**
+    - `EXPO_PUBLIC_GITHUB_OWNER`: データソースのGitHubユーザー名
+    - `EXPO_PUBLIC_GITHUB_REPO`: データソースのリポジトリ名
+
+- **オプション (データソースリポジトリがアプリリポジトリと異なる場合)**
+    - `ACCESS_TOKEN`: データソースリポジトリへ書き込み権限を持つPersonal Access Token (PAT)。
+        - **Classic PAT:** `repo` (Full control)
+        - **Fine-grained PAT:** `Contents` (Read and write) および `Workflows` (Read and write)
+
+### 実行
+```bash
+# Webで起動
+npm run web
+
+# iOS / Android (Expo Goが必要)
+npm run ios
+npm run android
+```
+
+## 現状の課題とロードマップ
+-   **データ永続性:** 現在GeoJSONは一時的なストレージ(File.io)に保存されているため、リンク切れのリスクがあります。GitHubリポジトリへの直接コミット等への移行を検討中です。
+-   **詳細画面:** ルートの詳細地図表示機能が未実装です。
+-   **検索機能:** フィルタリング機能のUI実装が必要です。
+
+---
+### 開発目的
+自然と接することが好きで、このようなポジティブ、健康的な趣味のため、いろんな安全かつ質が高いルート情報が必要です。いろんなサービスを見てきたが、有料であることがなかなか気が済まなくて．．．
+情報がハイキングユーザから集めるなら、すべてタダにするべき。


### PR DESCRIPTION
Rewrite `README.md` in Chinese as the primary documentation, including a vivid introduction, user guide, data privacy explanation, and detailed roadmap. Rename the original `README.md` to `README_JP.md` to preserve Japanese documentation. Update language badges to ensure correct navigation between language versions. Clarify the 'Git-as-Backend' architecture and current storage solutions.

---
*PR created automatically by Jules for task [3176503850468852557](https://jules.google.com/task/3176503850468852557) started by @yougikou*