### PR TITLE
Fix HomeScreen flicker and scroll restoration on back navigation

### DIFF
--- a/components/RouteCard.tsx
+++ b/components/RouteCard.tsx
@@ -10,13 +10,14 @@ import type { RouteIssue } from './apis/GitHubAPI';
 interface RouteCardProps {
   item: RouteIssue;
   index: number;
+  shouldAnimate?: boolean;
   onDetailPress: (item: RouteIssue) => void;
   onGpxPress: (title: string, uri: string | null) => void;
   onKmlPress: (title: string, uri: string | null) => void;
   onMapPress: (uri: string | null, title: string) => void;
 }
 
-const RouteCard = memo(({ item, index, onDetailPress, onGpxPress, onKmlPress, onMapPress }: RouteCardProps) => {
+const RouteCard = memo(({ item, index, shouldAnimate = true, onDetailPress, onGpxPress, onKmlPress, onMapPress }: RouteCardProps) => {
   const theme = useTheme();
   const geoJsonUri = item.geojson?.uri ?? null;
   const coverUri = item.coverimg?.uri ?? null;
@@ -30,7 +31,7 @@ const RouteCard = memo(({ item, index, onDetailPress, onGpxPress, onKmlPress, on
   const otherLabels = item.labels.filter(l => l.name !== difficultyLabel?.name);
 
   return (
-    <Animated.View entering={FadeInDown.delay(index * 50).springify()} style={{ flex: 1, padding: 8 }}>
+    <Animated.View entering={shouldAnimate ? FadeInDown.delay(index * 50).springify() : undefined} style={{ flex: 1, padding: 8 }}>
       <Pressable onPress={() => onDetailPress(item)} style={{ flex: 1 }}>
         <Surface style={[styles.cardSurface, { backgroundColor: theme.colors.surface }]} elevation={1}>
           {/* Image Section */}


### PR DESCRIPTION
This PR addresses the user report of "flickering" and "reloading feel" when navigating back to the Home Screen from a Detail Screen or using the browser back button.

Changes:
1.  **Scroll Restoration:** Switched from `useEffect` to `useLayoutEffect` in `HomeScreen` to handle scroll restoration synchronously (before paint) where possible, and utilized `FlashList`'s `initialScrollIndex` for a better initial render position.
2.  **Animation Control:** Introduced an `isRestored` ref in `HomeScreen` to track if the data is coming from the cache. This flag is passed to `RouteCard` via a new `shouldAnimate` prop.
3.  **RouteCard Update:** `RouteCard` now conditionally renders its entrance animation (`FadeInDown`) only when `shouldAnimate` is true (or undefined), effectively disabling the "re-entry" animation when the user is simply navigating back to the list.

These changes ensure the list appears instantly at the correct position without re-animating, mimicking a native navigation stack behavior.

---
*PR created automatically by Jules for task [18427514389332985020](https://jules.google.com/task/18427514389332985020) started by @yougikou*