### PR TITLE
Change data source to openroutes repo

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 EXPO_PUBLIC_GITHUB_OWNER=yougikou
-EXPO_PUBLIC_GITHUB_REPO=yougikou.github.io
-GITHUB_REPOSITORY=yougikou/yougikou.github.io
+EXPO_PUBLIC_GITHUB_REPO=openroutes
+GITHUB_REPOSITORY=yougikou/openroutes

--- a/components/apis/GitHubAPI.ts
+++ b/components/apis/GitHubAPI.ts
@@ -126,7 +126,7 @@ interface GitHubReleaseAsset {
 
 const fallbackRepoInfo = {
   owner: 'yougikou',
-  repo: 'yougikou.github.io',
+  repo: 'openroutes',
 };
 
 const resolveRepoInfo = () => {


### PR DESCRIPTION
Changed the data source repository to `openroutes` as requested. This involves updating the `.env` file and the fallback configuration in `components/apis/GitHubAPI.ts` to point to `yougikou/openroutes`.

---
*PR created automatically by Jules for task [16656286597983268815](https://jules.google.com/task/16656286597983268815) started by @yougikou*